### PR TITLE
New Firmware in version 113

### DIFF
--- a/plugins/wazo-gigaset/N720/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/N720/pkgs/pkgs.db
@@ -12,6 +12,6 @@ b-d: cp */sat*.bin Gigaset/
 
 [file_N720-fw]
 filename: N720_SW111.zip
-url: https://teamwork.gigaset.com/gigawiki/download/attachments/759175882/N720_SW_111.zip?version=1&modificationDate=1523875534000&api=v2&download=true
+url: https://teamwork.gigaset.com/gigawiki/download/attachments/881000796/N720_SW_113.zip?version=1&modificationDate=1551178986000&api=v2&download=true
 size: 2107221
 sha1sum: d1f4bfa552bf5abdf98f0eead1aeb3f34842e8c6


### PR DESCRIPTION
Update the link to upgrade the firmware from version 111 to 113.
No significant change in the technical operation of the device

**Exemple information of Gigaset Release Note of v112/113 :** 
Add 7 extra characters for CLIP/CNIP length.
Bugfixes:
* is not saved in Redial list
Blind transferee role does not work
Stability improvements

**Functional tested with Maxwell C and R630H**
