### PR TITLE
New Firmware in version 250

### DIFF
--- a/plugins/wazo-gigaset/N510/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/N510/pkgs/pkgs.db
@@ -11,6 +11,6 @@ b-c: cp */*.bin Gigaset/
 
 [file_N510-fw]
 filename: N510_SW_247.zip
-url: https://teamwork.gigaset.com/gigawiki/download/attachments/793117795/N510_SW_247.zip?version=1&modificationDate=1530101856000&api=v2&download=true
+url: https://teamwork.gigaset.com/gigawiki/download/attachments/926844154/N510_SW_250.zip?version=1&modificationDate=1561377527000&api=v2&download=true
 size: 5758048
 sha1sum: 1072d07336da81bbdf3fe5dbb2f1d44b4ccd1c88


### PR DESCRIPTION
Update the link to upgrade the firmware from version 247 to 250. 
Important improvements update and dialing with pause not possible

**Exemple information of Gigaset Release Note of v248/250 :**
[XSI phonebook] Only number in search (NAME)
Handling excessive reINVITEs with RTP sent in the wrong codec
Re-INVITE without SDP (MoH)
DNS-SRV improvement.
Fall-back during active call.
Subscribe when on Failover server is send to main server.
Saving LDAP entry in to local phone book.
BugFixes:
Possible reboot when dialing Feature code (#51)
Dialing with pause "P" not possible.
N510 Name resolution „Unknown“

**Functional tested with Maxwell C and R630H**