### PR TITLE
homogenize signaling and media dscp tag

### DIFF
--- a/plugins/xivo-aastra/common/templates/base.tpl
+++ b/plugins/xivo-aastra/common/templates/base.tpl
@@ -36,6 +36,9 @@ vlan id port 1: 4095
 tagging enabled: 0
 {% endif -%}
 
+tos sip: 46
+tos rtp: 46
+
 {# NTP settings -#}
 {% if ntp_enabled -%}
 time server disabled: 0

--- a/plugins/xivo-cisco-spa/common/templates/base.tpl
+++ b/plugins/xivo-cisco-spa/common/templates/base.tpl
@@ -71,6 +71,8 @@
 {% else -%}
 <DTMF_Tx_Method_{{ line_no }}_>Auto</DTMF_Tx_Method_{{ line_no }}_>
 {% endif -%}
+<SIP_ToS/DiffServ_Value_{{ line_no }}_>0xb8<SIP_ToS/DiffServ_Value_{{ line_no }}_>
+<RTP_ToS/DiffServ_Value_{{ line_no }}_>0xb8<RTP_ToS/DiffServ_Value_{{ line_no }}_>
 {% endfor -%}
 
 {% block suffix %}{% endblock %}

--- a/plugins/xivo-polycom/common/templates/base.tpl
+++ b/plugins/xivo-polycom/common/templates/base.tpl
@@ -11,6 +11,9 @@ device.net.vlanId="{{ vlan_id }}"
 device.net.vlanId=""
 {% endif -%}
 
+qos.ip.callControl.dscp EF
+qos.ip.rtp.dscp EF
+
 {# Syslog settings -#}
 device.syslog.serverName.set="1"
 device.syslog.transport.set="1"

--- a/plugins/xivo-snom/common/templates/base.tpl
+++ b/plugins/xivo-snom/common/templates/base.tpl
@@ -9,8 +9,8 @@
     <vlan_qos perm="R"></vlan_qos>
     {% endif -%}
     
-    <codec_tos perm="PERMISSIONFLAG">184</codec_tos> 
-    <signaling_tos perm="PERMISSIONFLAG">184</signaling_tos>
+    <codec_tos perm="R">184</codec_tos> 
+    <signaling_tos perm="R">184</signaling_tos>
 
     {% if admin_username -%}
     <http_user perm="R">{{ admin_username|e }}</http_user>

--- a/plugins/xivo-snom/common/templates/base.tpl
+++ b/plugins/xivo-snom/common/templates/base.tpl
@@ -8,6 +8,9 @@
     <vlan_id perm="R"></vlan_id>
     <vlan_qos perm="R"></vlan_qos>
     {% endif -%}
+    
+    <codec_tos perm="PERMISSIONFLAG">184</codec_tos> 
+    <signaling_tos perm="PERMISSIONFLAG">184</signaling_tos>
 
     {% if admin_username -%}
     <http_user perm="R">{{ admin_username|e }}</http_user>

--- a/plugins/xivo-yealink/v84/templates/base.tpl
+++ b/plugins/xivo-yealink/v84/templates/base.tpl
@@ -3,6 +3,9 @@
 static.auto_provision.pnp_enable = 0
 static.auto_provision.custom.protect = 1
 
+static.network.qos.audiotos 46
+static.network.qos.signaltos 46
+
 distinctive_ring_tones.alert_info.1.text = ring1
 distinctive_ring_tones.alert_info.2.text = ring2
 distinctive_ring_tones.alert_info.3.text = ring3


### PR DESCRIPTION
Depending on the manufacturer the telephones send different DSCP value.
To simplify the application of qos, it would be nice to have a homogeneous cofiguration.

Declaring explicitly in the templates the values DSCP is enough for me. Maybe in the future it would be nice to integrate these values into the provd device parameters.

Putting all the voice streams in DSCP EF seems like a good start.