### PR TITLE
xivo-snom: add MAC in firmware URL

### DIFF
--- a/plugins/xivo-snom/10.1.20.0/plugin-info
+++ b/plugins/xivo-snom/10.1.20.0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Plugin for Snom D785 in version 10.1.20.0.",
     "description_fr": "Greffon pour Snom série D785 en version 10.1.20.0.",
     "capabilities": {

--- a/plugins/xivo-snom/10.1.26.1/plugin-info
+++ b/plugins/xivo-snom/10.1.26.1/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Plugin for Snom D735 in version 10.1.26.1.",
     "description_fr": "Greffon pour Snom série D735 en version 10.1.26.1.",
     "capabilities": {

--- a/plugins/xivo-snom/8.7.5.35/plugin-info
+++ b/plugins/xivo-snom/8.7.5.35/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.8.4",
+    "version": "1.8.5",
     "description": "Plugin for Snom 300, 320, 370, 710/D710, 715/D715, 720, D725, 760, D765, 820, 821, 870, MP and PA1 in version 8.7.5.35.",
     "description_fr": "Greffon pour Snom 300, 320, 370, 710/D710, 715/D715, 720, D725, 760, D765, 820, 821, 870, MP et PA1 en version 8.7.5.35.",
     "capabilities": {

--- a/plugins/xivo-snom/8.9.3.40/plugin-info
+++ b/plugins/xivo-snom/8.9.3.40/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "Plugin for Snom D745 in version 8.9.3.40.",
     "description_fr": "Greffon pour Snom D745 en version 8.9.3.40.",
     "capabilities": {

--- a/plugins/xivo-snom/8.9.3.60/plugin-info
+++ b/plugins/xivo-snom/8.9.3.60/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Plugin for Snom D305, D315, D345 and D375 in version 8.9.3.60.",
     "description_fr": "Greffon pour Snom D305, D315, D345 and D375 en version 8.9.3.60.",
     "capabilities": {

--- a/plugins/xivo-snom/8.9.3.80/plugin-info
+++ b/plugins/xivo-snom/8.9.3.80/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Plugin for Snom D3x5, D7x5, D7x0 series in version 8.9.3.80.",
     "description_fr": "Greffon pour Snom séries D3x5; D7x5 et D7x0 en version 8.9.3.80.",
     "capabilities": {

--- a/plugins/xivo-snom/common/common.py
+++ b/plugins/xivo-snom/common/common.py
@@ -1,19 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2010-2019 The Wazo Authors  (see the AUTHORS file)
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>
+# Copyright 2010-2020 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 import os.path
@@ -45,13 +33,18 @@ class BaseSnomHTTPDeviceInfoExtractor(object):
         return defer.succeed(self._do_extract(request))
 
     def _do_extract(self, request):
+        device_info = {}
         ua = request.getHeader('User-Agent')
+        raw_mac = request.args.get('mac', [None])[0]
+        if raw_mac:
+            logger.debug('Got MAC from URL: %s', raw_mac)
+            device_info[u'mac'] = norm_mac(raw_mac.decode('ascii'))
         if ua:
-            dev_info = self._extract_from_ua(ua)
-            if dev_info:
-                self._extract_from_path(request.path, dev_info)
-                return dev_info
-        return None
+            info_from_ua = self._extract_from_ua(ua)
+            if info_from_ua:
+                device_info.update(info_from_ua)
+                self._extract_from_path(request.path, device_info)
+        return device_info
 
     def _extract_from_ua(self, ua):
         # HTTP User-Agent:

--- a/plugins/xivo-snom/common/templates/common/snom-model-firmware.xml.tpl.btpl
+++ b/plugins/xivo-snom/common/templates/common/snom-model-firmware.xml.tpl.btpl
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <firmware-settings>
-  <firmware>http://{{ ip }}:{{ http_port }}/firmware/#FW_FILENAME#</firmware>
+  <firmware>http://{{ ip }}:{{ http_port }}/firmware/#FW_FILENAME#?mac={mac}</firmware>
 </firmware-settings>


### PR DESCRIPTION
reason: snom720 does not send MAC in HTTP headers, making the firmware
file request look like an unknown device to provd.

Before: 
```
2019-12-04 13:34:56,735 [1644] (INFO) (twisted): x.x.x.x - - [04/Dec/2019:12:34:56 +0000] "GET /firmware/snom720-8.7.5.35-SIP-r.bin HTTP/1.1" 404 160 "-" "Mozilla/4.0 (compatible; snom720 8.7.5.35)"
```
After:
```
2020-01-14 09:07:53,364 [20037] (INFO) (twisted): x.x.x.x - - [14/Jan/2020:14:07:53 +0000] "GET /firmware/snom720-8.9.3.80-SIP-r.bin?mac=000000000000 HTTP/1.1" 200 22092256 "-" "Mozilla/4.0 (compatible; snom720 8.9.3.80)" 
```

ps: plugin already in testing repo