### PR TITLE
WAZO-1706: fix Aastra/Mitel firmware links

### DIFF
--- a/plugins/xivo-aastra/3.3.1-SP4/pkgs/pkgs.db
+++ b/plugins/xivo-aastra/3.3.1-SP4/pkgs/pkgs.db
@@ -123,12 +123,12 @@ b-c: cp */* i18n/
 
 [file_67XXi-fw]
 filename: 67XXi-fw.4365-8215.zip
-url: http://www.mitel.com/-/media/sip_3_3_1_4365_8215_sp4_hf9_all_moddels_08_2016-(13).zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/sip_3_3_1_4365_8215_sp4_hf9_all_moddels_08_2016-(13).zip
 size: 47398699
 sha1sum: ee7dc225c0d577088b0f32a0a5ebc231dc9608a8
 
 [file_lang]
 filename: 5801456-REV01_LangPacks_4_2_0_SP1.zip
-url: http://www.mitel.com/-/media/5801456-rev01_langpacks_4_2_0_sp1-(3).zip
+url: http://www.mitel.com/-/media/mitel/file/zip/open-solutions/5801456-rev01_langpacks_4_2_0_sp1-(3).zip
 size: 699938
 sha1sum: 5cd4344dde28b2ef61b3cfcf5f9a59e660abbb32

--- a/plugins/xivo-aastra/3.3.1-SP4/plugin-info
+++ b/plugins/xivo-aastra/3.3.1-SP4/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "2.2.3",
+    "version": "2.2.4",
     "description": "Plugin for Aastra/Mitel 67XXi, 9143i and 9480i in version 3.3.1 SP4 HF9.",
     "description_fr": "Greffon pour Aastra/Mitel 67XXi, 9143i et 9480i en version 3.3.1 SP4 HF9.",
     "capabilities": {

--- a/plugins/xivo-aastra/4.2.0/pkgs/pkgs.db
+++ b/plugins/xivo-aastra/4.2.0/pkgs/pkgs.db
@@ -23,11 +23,11 @@ b-c: cp 3.x_4.x_Lang_Files_April_01_2016/* i18n/
 
 
 [file_6800series-fw]
-url: https://www.mitel.com/-/media/mitel_sip_4_2_0_2023_sp2_ga_all_models_07_2016-(3).zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/mitel_sip_4_2_0_2023_sp2_ga_all_models_07_2016-(3).zip
 size: 158628135
 sha1sum: 0083b2ebe543f09a106c050d3235cf21bff48ffa
 
 [file_lang]
-url: https://www.mitel.com/-/media/5801456-rev01_langpacks_4_2_0_sp1-(8).zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/5801456-rev01_langpacks_4_2_0_sp1-(8).zip
 size: 699938
 sha1sum: 5cd4344dde28b2ef61b3cfcf5f9a59e660abbb32

--- a/plugins/xivo-aastra/4.2.0/plugin-info
+++ b/plugins/xivo-aastra/4.2.0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Plugin for Aastra/Mitel 6863i, 6865i, 6867i and 6869i in version 4.2.0.",
     "description_fr": "Greffon pour Aastra/Mitel 6863i, 6865i, 6867i et 6869i en version 4.2.0.",
     "capabilities": {

--- a/plugins/xivo-aastra/4.3.0/pkgs/pkgs.db
+++ b/plugins/xivo-aastra/4.3.0/pkgs/pkgs.db
@@ -76,12 +76,12 @@ b-c: cp * i18n/
 
 [file_68XXi-fw]
 filename: 68XXi-fw.2036.zip
-url: http://www.mitel.com/-/media/mitel_sip_4_3_0_2036_sp2_ga_all_models_05_2017.zip
+url: http://www.mitel.com/-/media/mitel/file/zip/open-solutions/mitel_sip_4_3_0_2036_sp2_ga_all_models_05_2017.zip
 size: 155741006
 sha1sum: 1d8090d5c0338efa77c949a5a5b4d5f976e34095
 
 [file_lang]
 filename: lang.2036.zip
-url: http://www.mitel.com/-/media/5801456rev01langpacks430sp1-10.zip
+url: http://www.mitel.com/-/media/mitel/file/zip/open-solutions/5801456rev01langpacks430sp1-10.zip
 size: 799471
 sha1sum: 1590c0069d7b374df07048eecdf74818591aaea9

--- a/plugins/xivo-aastra/4.3.0/plugin-info
+++ b/plugins/xivo-aastra/4.3.0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "Plugin for Aastra/Mitel 6863i, 6865i, 6867i, 6869i and 6873i in version 4.3.0. SP2",
     "description_fr": "Greffon pour Aastra/Mitel 6863i, 6865i, 6867i, 6869i et 6873i en version 4.3.0. SP2",
     "capabilities": {

--- a/plugins/xivo-aastra/5.0.0/pkgs/pkgs.db
+++ b/plugins/xivo-aastra/5.0.0/pkgs/pkgs.db
@@ -71,36 +71,36 @@ b-c: cp * i18n/
 
 [file_6863i-fw]
 filename: 58015370REV035001018SP16863i.zip
-url: https://www.mitel.com/-/media/mitel/file/zip/unsorted-zips/58015370rev035001018sp16863i.zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/58015370rev035001018sp16863i.zip
 size: 12223593
 sha1sum: 2ae6e15f06254209e6966f9d114f746844a183ae
 
 [file_6865i-fw]
 filename: 58015371REV035001018SP16865i.zip
-url: https://www.mitel.com/-/media/mitel/file/zip/unsorted-zips/58015371rev035001018sp16865i.zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/58015371rev035001018sp16865i.zip
 size: 24858245
 sha1sum: dc9c11d843a74fcd47d778079aa46dd8640075a8
 
 [file_6867i-fw]
 filename: 58015372REV035001018SP16867i.zip
-url: https://www.mitel.com/-/media/mitel/file/zip/unsorted-zips/58015372rev035001018sp16867i.zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/58015372rev035001018sp16867i.zip
 size: 44267740
 sha1sum: c5050f4a134a734a82d5aa20d3c1be4d6bc5321e
 
 [file_6869i-fw]
 filename: 58015373rev035001018sp16869i.zip
-url: https://www.mitel.com/-/media/mitel/file/zip/unsorted-zips/58015373rev035001018sp16869i.zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/58015373rev035001018sp16869i.zip
 size: 44968084
 sha1sum: 8ad19807445ac1af8f44002388c054a8bc8755b6
 
 [file_6873i-fw]
 filename: 58015374REV035001018SP16873i.zip
-url: https://www.mitel.com/-/media/mitel/file/zip/unsorted-zips/58015374rev035001018sp16873i.zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/58015374rev035001018sp16873i.zip
 size: 36675325
 sha1sum: 569b2b4629073c6d1b9404bc1251bc8aa69a647d
 
 [file_lang]
 filename: R500 6800 5801456REV00LangPacks3.zip
-url: https://www.mitel.com/-/media/mitel/file/zip/unsorted-zips/r500-6800-5801456rev00langpacks3.zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/r500-6800-5801456rev00langpacks3.zip
 size: 905670
 sha1sum: 931ca34c03f43713d59e7afe1f5cf5ca5e114b0a


### PR DESCRIPTION
Mitel moved everything to subdirectory `/mitel/file/zip/open-solutions/`

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1706