### PR TITLE
WAZO-1713: fix aastra default values

### DIFF
--- a/plugins/xivo-aastra/3.3.1-SP4/plugin-info
+++ b/plugins/xivo-aastra/3.3.1-SP4/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "Plugin for Aastra/Mitel 67XXi, 9143i and 9480i in version 3.3.1 SP4 HF9.",
     "description_fr": "Greffon pour Aastra/Mitel 67XXi, 9143i et 9480i en version 3.3.1 SP4 HF9.",
     "capabilities": {

--- a/plugins/xivo-aastra/4.2.0/plugin-info
+++ b/plugins/xivo-aastra/4.2.0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Plugin for Aastra/Mitel 6863i, 6865i, 6867i and 6869i in version 4.2.0.",
     "description_fr": "Greffon pour Aastra/Mitel 6863i, 6865i, 6867i et 6869i en version 4.2.0.",
     "capabilities": {

--- a/plugins/xivo-aastra/4.3.0/plugin-info
+++ b/plugins/xivo-aastra/4.3.0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.4",
+    "version": "2.1.5",
     "description": "Plugin for Aastra/Mitel 6863i, 6865i, 6867i, 6869i and 6873i in version 4.3.0. SP2",
     "description_fr": "Greffon pour Aastra/Mitel 6863i, 6865i, 6867i, 6869i et 6873i en version 4.3.0. SP2",
     "capabilities": {

--- a/plugins/xivo-aastra/5.0.0/plugin-info
+++ b/plugins/xivo-aastra/5.0.0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Plugin for Aastra/Mitel 6863i, 6865i, 6867i, 6869i and 6873i in version 5.0.0 SP1",
     "description_fr": "Greffon pour Aastra/Mitel 6863i, 6865i, 6867i, 6869i et 6873i en version 5.0.0 SP1",
     "capabilities": {

--- a/plugins/xivo-aastra/common/common.py
+++ b/plugins/xivo-aastra/common/common.py
@@ -376,13 +376,13 @@ class BaseAastraPlugin(StandardPlugin):
 
     def _update_sip_lines(self, raw_config):
         proxy_ip = raw_config.get(u'sip_proxy_ip')
-        proxy_port = raw_config.get(u'sip_proxy_port', u'0')
+        proxy_port = raw_config.get(u'sip_proxy_port', u'5060')
         backup_proxy_ip = raw_config.get(u'sip_backup_proxy_ip', u'0.0.0.0')
-        backup_proxy_port = raw_config.get(u'sip_backup_proxy_port', u'0')
+        backup_proxy_port = raw_config.get(u'sip_backup_proxy_port', u'5060')
         registrar_ip = raw_config.get(u'sip_registrar_ip')
-        registrar_port = raw_config.get(u'sip_registrar_port', u'0')
+        registrar_port = raw_config.get(u'sip_registrar_port', u'5060')
         backup_registrar_ip = raw_config.get(u'sip_backup_registrar_ip', u'0.0.0.0')
-        backup_registrar_port = raw_config.get(u'sip_backup_registrar_port', u'0')
+        backup_registrar_port = raw_config.get(u'sip_backup_registrar_port', u'5060')
         dtmf_mode = raw_config.get(u'sip_dtmf_mode')
         srtp_mode = raw_config.get(u'sip_srtp_mode')
         voicemail = raw_config.get(u'exten_voicemail')


### PR DESCRIPTION
When the SIP port is not defined in the provisioning configuration, it should be 5060, not 0.
This causes issues with phones that cannot make calls if the port is set to 0.