### PR TITLE
Revert "set dscp 46 for cisco spa phone"

### DIFF
--- a/plugins/xivo-cisco-spa/common/templates/base.tpl
+++ b/plugins/xivo-cisco-spa/common/templates/base.tpl
@@ -71,8 +71,6 @@
 {% else -%}
 <DTMF_Tx_Method_{{ line_no }}_>Auto</DTMF_Tx_Method_{{ line_no }}_>
 {% endif -%}
-<SIP_ToS/DiffServ_Value_{{ line_no }}_>0xb8<SIP_ToS/DiffServ_Value_{{ line_no }}_>
-<RTP_ToS/DiffServ_Value_{{ line_no }}_>0xb8<RTP_ToS/DiffServ_Value_{{ line_no }}_>
 {% endfor -%}
 
 {% block suffix %}{% endblock %}


### PR DESCRIPTION
This reverts commit bfbc63e6a1c4c33ce1acccc63ac0fe4bbf0ab6a5.

This config is not working, and some time prevent phone to get his config properly.