### PR TITLE
[WAZO-1787] Yealink: fix proxy_port missing on line in v83

### DIFF
--- a/plugins/xivo-yealink/v83/common.py
+++ b/plugins/xivo-yealink/v83/common.py
@@ -416,7 +416,9 @@ class BaseYealinkPlugin(StandardPlugin):
             if u'proxy_port' not in line and u'sip_proxy_port' in raw_config:
                 line[u'proxy_port'] = raw_config[u'sip_proxy_port']
             # set SIP template to use
-            template_id = raw_config['XX_templates'].get((line[u'proxy_ip'], line[u'proxy_port']), {}).get('id')
+            template_id = raw_config['XX_templates'].get(
+                (line.get(u'proxy_ip'), line.get(u'proxy_port', 5060)), {}
+            ).get('id')
             line[u'XX_template_id'] = template_id or 1
 
     def _add_sip_templates(self, raw_config):

--- a/plugins/xivo-yealink/v83/plugin-info
+++ b/plugins/xivo-yealink/v83/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Plugin for Yealink for all T2X, T4X, T5X, W60 and W80B series in version V83.",
     "description_fr": "Greffon pour Yealink pour toutes les series T2X, T4X, T5X, W60 et W80B en version V83.",
     "vendor" : "Yealink",


### PR DESCRIPTION
This bug has been introduced by the addition of W80B previously.