### PR TITLE
WAZO-2216: fix Gigaset firmware URLs

### DIFF
--- a/plugins/wazo-gigaset/N510/entry.py
+++ b/plugins/wazo-gigaset/N510/entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 common = {}
@@ -7,7 +7,7 @@ execfile_('common.py', common)
 
 
 MODEL_VERSIONS = {
-    u'N510 IP PRO': u'42.250',
+    u'N510 IP PRO': u'42.258',
 }
 
 

--- a/plugins/wazo-gigaset/N510/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/N510/pkgs/pkgs.db
@@ -1,7 +1,7 @@
 [pkg_N510-fw]
 description: Firmware for Gigaset N510 IP PRO
 description_fr: Micrologiciel pour Gigaset N510 IP PRO
-version: 42.250
+version: 42.258
 files: N510-fw
 install: gigasetn510-fw
 
@@ -10,7 +10,7 @@ a-b: unzip $FILE1
 b-c: cp */*.bin Gigaset/
 
 [file_N510-fw]
-filename: N510_SW_250.zip
-url: https://teamwork.gigaset.com/gigawiki/download/attachments/926844154/N510_SW_250.zip?version=1&modificationDate=1561377527000&api=v2&download=true
-size: 5789114
-sha1sum: 3509432aac911b0010677a2bf90dd20a3d41f331
+filename: N510_SW_258.zip
+url: https://teamwork.gigaset.com/gigawiki/download/attachments/1171554762/N510_SW_258.zip?version=1&modificationDate=1605603398000&api=v2
+size: 5823580
+sha1sum: 355fbfc2a088e4cd0af07581cafc320657bd1695

--- a/plugins/wazo-gigaset/N510/plugin-info
+++ b/plugins/wazo-gigaset/N510/plugin-info
@@ -3,7 +3,7 @@
     "description": "Plugin for Gigaset N510 IP",
     "description_fr": "Greffon pour Gigaset N510 IP",
     "capabilities": {
-        "Gigaset, N510 IP PRO, 42.250": {
+        "Gigaset, N510 IP PRO, 42.258": {
             "lines": 6,
             "high_availability": false,
             "function_keys": 0,

--- a/plugins/wazo-gigaset/N510/plugin-info
+++ b/plugins/wazo-gigaset/N510/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Plugin for Gigaset N510 IP",
     "description_fr": "Greffon pour Gigaset N510 IP",
     "capabilities": {

--- a/plugins/wazo-gigaset/N510/templates/base.tpl
+++ b/plugins/wazo-gigaset/N510/templates/base.tpl
@@ -8,7 +8,7 @@
     <MAC_ADDRESS value="{{ XX_mac_addr }}"/>
     <PROFILE_NAME class="string" value="N510"/>
     {%- if http_port %}
-    <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/merkur247_42.bin"'/>
+    <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/merkur250_42.bin"'/>
     {%- endif %}
 <!-- Allow access from other networks. -->
     <SYMB_ITEM ID="BS_IP_Data1.ucB_ACCEPT_FOREIGN_SUBNET" class="symb_item" value="0x1"/>

--- a/plugins/wazo-gigaset/N510/templates/base.tpl
+++ b/plugins/wazo-gigaset/N510/templates/base.tpl
@@ -8,7 +8,7 @@
     <MAC_ADDRESS value="{{ XX_mac_addr }}"/>
     <PROFILE_NAME class="string" value="N510"/>
     {%- if http_port %}
-    <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/merkur250_42.bin"'/>
+    <S_SPECIAL_DATA_SRV class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/merkur250_42.bin"'/>
     {%- endif %}
 <!-- Allow access from other networks. -->
     <SYMB_ITEM ID="BS_IP_Data1.ucB_ACCEPT_FOREIGN_SUBNET" class="symb_item" value="0x1"/>

--- a/plugins/wazo-gigaset/N510/templates/base.tpl
+++ b/plugins/wazo-gigaset/N510/templates/base.tpl
@@ -8,7 +8,7 @@
     <MAC_ADDRESS value="{{ XX_mac_addr }}"/>
     <PROFILE_NAME class="string" value="N510"/>
     {%- if http_port %}
-    <S_SPECIAL_DATA_SRV class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/merkur250_42.bin"'/>
+    <S_SPECIAL_DATA_SRV class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/merkur258_42.bin"'/>
     {%- endif %}
 <!-- Allow access from other networks. -->
     <SYMB_ITEM ID="BS_IP_Data1.ucB_ACCEPT_FOREIGN_SUBNET" class="symb_item" value="0x1"/>

--- a/plugins/wazo-gigaset/common/common.py
+++ b/plugins/wazo-gigaset/common/common.py
@@ -83,8 +83,8 @@ class GigasetHTTPDeviceInfoExtractor(object):
         # "N720-DM-PRO/70.040.00.000.000"
         # "N510 IP PRO/42.245.00.000.000;7C2F804DF9A9"
         # "N510 IP PRO/42.245.00.000.000"
-        # "N510 IP PRO/42.250.00.000.000;7C2F806257D7"
-        # "N510 IP PRO/42.250.00.000.000"
+        # "N510 IP PRO/42.258.00.000.000;7C2F806257D7"
+        # "N510 IP PRO/42.258.00.000.000"
         m = self._UA_REGEX.search(ua)
         dev_info = {}
         if m:


### PR DESCRIPTION
Instead of only fixing it, I upgraded to the lastest version.