### PR TITLE
yealink-v85: disable text messaging

### DIFF
--- a/plugins/xivo-yealink/v85/plugin-info
+++ b/plugins/xivo-yealink/v85/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Plugin for Yealink for CP920, CP960, T2X, T3X, T4X, T5X and W60 series in version V85.",
     "description_fr": "Greffon pour Yealink pour les series CP920, CP960, T2X, T3X, T4X, T5X et W60 en version V85.",
     "vendor" : "Yealink",

--- a/plugins/xivo-yealink/v85/templates/base.tpl
+++ b/plugins/xivo-yealink/v85/templates/base.tpl
@@ -21,6 +21,8 @@ distinctive_ring_tones.alert_info.7.ringer = 7
 distinctive_ring_tones.alert_info.8.ringer = 8
 
 features.caller_name_type_on_dialing = 1
+features.text_message.enable = 0
+features.text_message_popup.enable = 0
 
 local_time.date_format = 2
 


### PR DESCRIPTION
Why: in a conference, it displays multiple text messages after we are done with
the call. This is not a wanted behaviour in our case.