### PR TITLE
fanvil: homogenize metadata for high availability

### DIFF
--- a/plugins/wazo-fanvil/2.3/plugin-info
+++ b/plugins/wazo-fanvil/2.3/plugin-info
@@ -35,31 +35,31 @@
         },
         "Fanvil, X3S, 2.3": {
             "lines": 2,
-            "high_availability" : 0,
+            "high_availability": false,
             "function_keys" : 0,
             "protocol" : "sip"
         },
         "Fanvil, X4, 2.3": {
             "lines": 4,
-            "high_availability" : 0,
+            "high_availability": false,
             "function_keys" : 12,
             "protocol" : "sip"
         },
         "Fanvil, X5, 2.3": {
             "lines": 6,
-            "high_availability" : 0,
+            "high_availability": false,
             "function_keys" : 40,
             "protocol" : "sip"
         },
         "Fanvil, X5S, 2.3": {
             "lines": 6,
-            "high_availability" : 0,
+            "high_availability": false,
             "function_keys" : 40,
             "protocol" : "sip"
         },
         "Fanvil, X6, 2.3": {
             "lines": 6,
-            "high_availability" : 0,
+            "high_availability": false,
             "function_keys" : 60,
             "protocol" : "sip"
         }


### PR DESCRIPTION
Why:

* This causes a warning during the generation of the wazo-platform.org
doc