### PR TITLE
jays: add T46U model

### DIFF
--- a/plugins/wazo-yealink/v85/common.py
+++ b/plugins/wazo-yealink/v85/common.py
@@ -67,7 +67,6 @@ class BaseYealinkHTTPDeviceInfoExtractor(object):
         #   "Yealink SIP-T33G 124.85.257.55 80:5e:c0:bd:ea:ef"
         #   "Yealink W90DM 130.85.0.15 80:5e:c0:d9:c7:44"
         #   "Yealink SIP-T46U 180.85.0.54 80:5E:C0:78:29:65"
-        
 
         for UA_REGEX in self._UA_REGEX_LIST:
             m = UA_REGEX.match(ua)

--- a/plugins/wazo-yealink/v85/common.py
+++ b/plugins/wazo-yealink/v85/common.py
@@ -66,6 +66,8 @@ class BaseYealinkHTTPDeviceInfoExtractor(object):
         #   "Yealink SIP-T31G 124.85.257.55 80:5e:c0:d5:7d:72"
         #   "Yealink SIP-T33G 124.85.257.55 80:5e:c0:bd:ea:ef"
         #   "Yealink W90DM 130.85.0.15 80:5e:c0:d9:c7:44"
+        #   "Yealink SIP-T46U 180.85.0.54 80:5E:C0:78:29:65"
+        
 
         for UA_REGEX in self._UA_REGEX_LIST:
             m = UA_REGEX.match(ua)
@@ -215,6 +217,7 @@ class BaseYealinkFunckeyPrefixIterator(object):
         u'W60B': 0,
         u'W90DM': 0,
         u'W90B': 0,
+        u'T46U': 27,
     }
     _NB_MEMORYKEY = {
         u'CP920': 0,
@@ -240,6 +243,7 @@ class BaseYealinkFunckeyPrefixIterator(object):
         u'W60B': 0,
         u'W90DM': 0,
         u'W90B': 0,
+        u'T46U': 0,
     }
 
     class NullExpansionModule(object):
@@ -341,6 +345,7 @@ class BaseYealinkPlugin(StandardPlugin):
         u'W60B': 8,
         u'W90DM': 250,
         u'W90B': 0,
+        u'T46U': 16,
     }
 
     def __init__(self, app, plugin_dir, gen_cfg, spec_cfg):

--- a/plugins/wazo-yealink/v85/entry.py
+++ b/plugins/wazo-yealink/v85/entry.py
@@ -31,6 +31,7 @@ MODEL_VERSIONS = {
     u'W60B': u'77.85.0.25',
     u'W90DM': u'130.85.0.15',
     u'W90B': u'130.85.0.15',
+    u'T46U': u'180.85.0.63',
 }
 
 COMMON_FILES = [
@@ -44,6 +45,7 @@ COMMON_FILES = [
     ('y000000000123.cfg', u'T31(T30,T30P,T31G,T31P,T33P,T33G)-124.85.0.40.rom', 'model.tpl'),
     ('y000000000124.cfg', u'T31(T30,T30P,T31G,T31P,T33P,T33G)-124.85.0.40.rom', 'model.tpl'),
     ('y000000000127.cfg', u'T31(T30,T30P,T31G,T31P,T33P,T33G)-124.85.0.40.rom', 'model.tpl'),
+    ('y000000000108.cfg', u'T46U(T43U,T46U,T41U,T48U,T42U)-108.85.0.63.rom', 'model.tpl'),
 ]
 
 HANDSETS_FW = {

--- a/plugins/wazo-yealink/v85/pkgs/pkgs.db
+++ b/plugins/wazo-yealink/v85/pkgs/pkgs.db
@@ -19,6 +19,13 @@ version: 66.85.0.5
 files: T46S_T48S_T42S_T41S-fw
 install: yealink-fw
 
+[pkg_T46U_T48U_T43U_T42U-fw]
+description: Firmware for Yealink T46U T48U T42U and T43U
+description_fr: Micrologiciel pour Yealink T46U T48U T42U et T43U
+version: 108.85.0.63
+files: T46U_T48U_T42U_T43U-fw
+install: yealink-fw
+
 [pkg_T53_T53W_T54W_T57W-fw]
 description: Firmware for Yealink T53 T53W T54W and T57W
 description_fr: Micrologiciel pour Yealink T53 T53W T54W et T57W
@@ -154,6 +161,13 @@ filename: T46S(T48S,T42S,T41S)-66.85.0.5.rom
 url: http://support.yealink.com/forward2download?path=ZIjHOJbWuW/DFrGTLnGypkTJASVqwzX/x71yaViKhXSKOgYSKl0Pb7N9IXFpYf7YAOhOJmV0fGjbcYgmf0b9uxGdQ1IFTWkfgTz2m4g5Uoy1NWm3/S6JBTsplusSymbolM5UOVemCq9Kf2pvmyoc=
 size: 25559152
 sha1sum: 091d469ba3ce13b424a5212fb74f0e1b59c31a6a
+
+[file_T46U_T48U_T42U_T43U-fw]
+filename: 
+url: https://fileonline.yealink.com/?Command=DownloadFileShare&FileToken=0&ShareToken=704C2A2B6953F5AA4C5732C442CCCAD1786B968F
+size: 37705936
+sha1sum:  a5c721d6e2f50d88186187080c4b9a404fb948cb
+
 
 [file_T53_T53W_T54W_T57W-fw]
 filename: T54W(T57W,T53W,T53)-96.85.0.5.rom

--- a/plugins/wazo-yealink/v85/plugin-info
+++ b/plugins/wazo-yealink/v85/plugin-info
@@ -1,7 +1,7 @@
 {
     "version": "1.0.8",
-    "description": "Plugin for Yealink for CP920, CP960, T2X, T3X, T4X, T5X, W60 and W90 series in version V85.",
-    "description_fr": "Greffon pour Yealink pour les series CP920, CP960, T2X, T3X, T4X, T5X, W60 et W90 en version V85.",
+    "description": "Plugin for Yealink for CP920, CP960, T2X, T3X, T4X, T4UX, T5X, W60 and W90 series in version V85.",
+    "description_fr": "Greffon pour Yealink pour les series CP920, CP960, T2X, T3X, T4X, T4UX, T5X, W60 et W90 en version V85.",
     "vendor" : "Yealink",
     "vendor.url" : "http://www.yealink.com",
     "vendor.description" : "Companies choose Yealink for that enable their geographically dispersed workforces to communicate and collaborate more effectively and productively over distances. Through the service provided by Yealink, people connect and collaborate from their desktops, meeting rooms, class rooms, and mobile setting.",
@@ -160,6 +160,15 @@
             "switchboard": false,
             "type": "dect",
             "multicell": true,
+            "protocol": "sip"
+        }
+		"Yealink, T46U, 108.85.0.63": {
+            "lines": 16,
+            "high_availability": true,
+            "function_keys": 27,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
             "protocol": "sip"
         }
     }

--- a/plugins/wazo-yealink/v85/plugin-info
+++ b/plugins/wazo-yealink/v85/plugin-info
@@ -88,6 +88,15 @@
             "type": "deskphone",
             "protocol": "sip"
         },
+        "Yealink, T46U, 108.85.0.63": {
+            "lines": 16,
+            "high_availability": true,
+            "function_keys": 27,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
         "Yealink, T48S, 66.85.0.5": {
             "lines": 16,
             "high_availability": true,
@@ -160,15 +169,6 @@
             "switchboard": false,
             "type": "dect",
             "multicell": true,
-            "protocol": "sip"
-        }
-		"Yealink, T46U, 108.85.0.63": {
-            "lines": 16,
-            "high_availability": true,
-            "function_keys": 27,
-            "expansion_modules": 0,
-            "switchboard": false,
-            "type": "deskphone",
             "protocol": "sip"
         }
     }

--- a/plugins/wazo-yealink/v85/plugin-info
+++ b/plugins/wazo-yealink/v85/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Plugin for Yealink for CP920, CP960, T2X, T3X, T4X, T4UX, T5X, W60 and W90 series in version V85.",
     "description_fr": "Greffon pour Yealink pour les series CP920, CP960, T2X, T3X, T4X, T4UX, T5X, W60 et W90 en version V85.",
     "vendor" : "Yealink",

--- a/plugins/wazo-yealink/v85/templates/T46U.tpl
+++ b/plugins/wazo-yealink/v85/templates/T46U.tpl
@@ -1,0 +1,5 @@
+{% extends 'base.tpl' -%}
+
+{% block model_specific_parameters -%}
+gui_lang.url = http://{{ ip }}:{{ http_port }}/lang/T46S-T54W/004.GUI.French.lang
+{% endblock %}


### PR DESCRIPTION
If this model is available, then I will go to update other T4xU models.
Note:
1. T4xU supports a new expansion module - EXP43 (20 physical keys with dual-color LEDs, 3 pages)
2. the firmware URL still needs to update as the address in your server. Please help to update.