### PR TITLE
Add missing Yealink W90 metadata

### DIFF
--- a/plugins/xivo-yealink/v85/pkgs/pkgs.db
+++ b/plugins/xivo-yealink/v85/pkgs/pkgs.db
@@ -40,6 +40,20 @@ version: 77.85.0.25
 files: W60B-fw
 install: yealink-fw
 
+[pkg_W90B-fw]
+description: Firmware for Yealink W90B
+description_fr: Micrologiciel pour Yealink W90B
+version: 130.85.0.15
+files: W90B-fw
+install: yealink-fw
+
+[pkg_W90DM-fw]
+description: Firmware for Yealink W90DM
+description_fr: Micrologiciel pour Yealink W90DM
+version: 130.85.0.15
+files: W90DM-fw
+install: yealink-fw
+
 [pkg_W53H-fw]
 description: Firmware for Yealink W53H handset
 description_fr: Micrologiciel pour le combiné Yealink W53H
@@ -158,6 +172,18 @@ filename: W60B-77.85.0.25.rom
 url: https://support.yealink.com/forward2download?path=ZIjHOJbWuW/DFrGTLnGyprkfRlGTqdFMbAVf81NnTP/95/FVRL1rtzoORnY1HnveXt6bnGL0gA4Bj7MGid1rCEhkzMxpR6ozQ7FKzkLUH9JXmw7Gcc2TFg==
 size: 10732848
 sha1sum: 73f3d3485395e53bb647f7da270a49f13acca6c0
+
+[file_W90DM-fw]
+filename: W90DM-130.85.0.15.rom
+url: http://provd.wazo.community/firmwares/yealink/W90DM-130.85.0.15.rom
+size: 22057776
+sha1sum: 57232fc46b564cc1e0e0e7a8efe3a6d295057bdd
+
+[file_W90B-fw]
+filename: W90B-130.85.0.15.rom
+url: http://provd.wazo.community/firmwares/yealink/W90B-130.85.0.15.rom
+size: 22057840
+sha1sum: 0fc2e1093956341ff0b3f230af526c279de98595
 
 [file_W53H-fw]
 filename: W53H-88.85.0.20.rom

--- a/plugins/xivo-yealink/v85/plugin-info
+++ b/plugins/xivo-yealink/v85/plugin-info
@@ -1,7 +1,7 @@
 {
-    "version": "1.0.6",
-    "description": "Plugin for Yealink for CP920, CP960, T2X, T3X, T4X, T5X and W60 series in version V85.",
-    "description_fr": "Greffon pour Yealink pour les series CP920, CP960, T2X, T3X, T4X, T5X et W60 en version V85.",
+    "version": "1.0.7",
+    "description": "Plugin for Yealink for CP920, CP960, T2X, T3X, T4X, T5X, W60 and W90 series in version V85.",
+    "description_fr": "Greffon pour Yealink pour les series CP920, CP960, T2X, T3X, T4X, T5X, W60 et W90 en version V85.",
     "vendor" : "Yealink",
     "vendor.url" : "http://www.yealink.com",
     "vendor.description" : "Companies choose Yealink for that enable their geographically dispersed workforces to communicate and collaborate more effectively and productively over distances. Through the service provided by Yealink, people connect and collaborate from their desktops, meeting rooms, class rooms, and mobile setting.",
@@ -150,6 +150,16 @@
             "switchboard": false,
             "type": "dect",
             "multicell": false,
+            "protocol": "sip"
+        },
+        "Yealink, W90DM, 130.85.0.15": {
+            "lines": 250,
+            "high_availability": false,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": true,
             "protocol": "sip"
         }
     }


### PR DESCRIPTION
A bad rebase caused the deletion of this information.