### PR TITLE
disable ring splash function

### DIFF
--- a/plugins/xivo-aastra/5.0.0/plugin-info
+++ b/plugins/xivo-aastra/5.0.0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "Plugin for Aastra/Mitel 6863i, 6865i, 6867i, 6869i and 6873i in version 5.0.0 SP1",
     "description_fr": "Greffon pour Aastra/Mitel 6863i, 6865i, 6867i, 6869i et 6873i en version 5.0.0 SP1",
     "capabilities": {

--- a/plugins/xivo-aastra/common/templates/6863i.tpl
+++ b/plugins/xivo-aastra/common/templates/6863i.tpl
@@ -2,6 +2,6 @@
 directory script: {{ XX_xivo_phonebook_url }}
 {% endif -%}
 
-play a ring splash: 1
+play a ring splash: 0
 
 {% include 'base.tpl' %}

--- a/plugins/xivo-aastra/common/templates/6865i.tpl
+++ b/plugins/xivo-aastra/common/templates/6865i.tpl
@@ -2,7 +2,7 @@ prgkey5 locked: 0
 
 prgkey6 locked: 0
 
-play a ring splash: 1
+play a ring splash: 0
 
 {% if XX_xivo_phonebook_url -%}
 prgkey5 type: none

--- a/plugins/xivo-aastra/common/templates/6867i.tpl
+++ b/plugins/xivo-aastra/common/templates/6867i.tpl
@@ -1,5 +1,5 @@
 idle screen mode: 1
-play a ring splash: 1
+play a ring splash: 0
 
 {% if XX_xivo_phonebook_url -%}
 directory script: {{ XX_xivo_phonebook_url }}

--- a/plugins/xivo-aastra/common/templates/6869i.tpl
+++ b/plugins/xivo-aastra/common/templates/6869i.tpl
@@ -1,6 +1,6 @@
 idle screen mode: 1
 
-play a ring splash: 1
+play a ring splash: 0
 
 topsoftkey1 type: directory
 


### PR DESCRIPTION
commit : https://github.com/wazo-platform/wazo-provd-plugins/commit/02df5823da4f571286947a0201726358e356eb91#diff-62f83ccec46cc554c6fd031e097f23c4712805b7ac81275e9d34424c0c9805d0 
adding the option to a side effect.
when you have BLF keys configured if one of the users of these keys receives a call, it sounds a ringing tone on the sets which supervise it.