### PR TITLE
Gigaset N510 enhancements

### DIFF
--- a/plugins/wazo-gigaset/N510/plugin-info
+++ b/plugins/wazo-gigaset/N510/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Plugin for Gigaset N510 IP",
     "description_fr": "Greffon pour Gigaset N510 IP",
     "capabilities": {

--- a/plugins/wazo-gigaset/N510/templates/base.tpl
+++ b/plugins/wazo-gigaset/N510/templates/base.tpl
@@ -31,6 +31,8 @@
     {%- set line_suffix = '_' + line_no %}
     {%- endif %}
     <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].aucAccountName[0]" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
+    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiSendMask" class="symb_item" value="0x0{{ "%x"|format(line_no|int()) }}"/>
+    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiReceiveMask" class="symb_item" value="0x0{{ "%x"|format(line_no|int()) }}"/>
     <SYMB_ITEM ID="BS_IP_Data1.aucS_SIP_ACCOUNT_NAME_{{ line_no }}" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
     <SYMB_ITEM ID="BS_IP_Data1.aucS_SIP_DISPLAYNAME{{ line_suffix }}" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
     <SYMB_ITEM ID="BS_IP_Data3.aucS_SIP_LOGIN_ID{{ line_suffix }}" class="symb_item" value='"{{ line['auth_username']|d(line['username']) }}"'/>

--- a/plugins/wazo-gigaset/N510/templates/base.tpl
+++ b/plugins/wazo-gigaset/N510/templates/base.tpl
@@ -8,7 +8,7 @@
     <MAC_ADDRESS value="{{ XX_mac_addr }}"/>
     <PROFILE_NAME class="string" value="N510"/>
     {%- if http_port %}
-    <S_SPECIAL_DATA_SRV class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/merkur258_42.bin"'/>
+    <S_SPECIAL_DATA_SRV class="string" value='"http://profile.gigaset.net/device/42/merkur258_42.bin"'/>
     {%- endif %}
 <!-- Allow access from other networks. -->
     <SYMB_ITEM ID="BS_IP_Data1.ucB_ACCEPT_FOREIGN_SUBNET" class="symb_item" value="0x1"/>


### PR DESCRIPTION
Hello,

This PR enhances Gigaset N510 plugin.

First, it enables firmware auto-update, thanks to properly formatted links provided by Gigaset.
As found in the documentation :
https://teamwork.gigaset.com/gigawiki/display/GPPPO/Direct+link+to+Firmware+file
While here, also update to last firmware version.
https://teamwork.gigaset.com/gigawiki/display/GPPPO/Firmware+N510+IP+PRO

It also properly assign each DECT to its SIP line only.
By default, on N510, all DECT ring / receive calls for all the 6 configured SIP accounts.
And all DECT make outgoing calls from the first configured SIP account.
Which does not make sense...
This PR then properly assign each DECT to its proper SIP account : first DECT to first SIP account, second DECT to second SIP account etc..
Which is then the expected behaviour...

Thank you 👍