### PR TITLE
Yealink enhancements

### DIFF
--- a/plugins/wazo-yealink/v86/plugin-info
+++ b/plugins/wazo-yealink/v86/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "Plugin for Yealink for CP920, T27G, T3X, T4X and T5X series in version 86.",
     "description_fr": "Greffon pour Yealink pour les series CP920, T27G, T3X, T4X et T5X en version 86.",
     "vendor" : "Yealink",

--- a/plugins/wazo-yealink/v86/templates/base.tpl
+++ b/plugins/wazo-yealink/v86/templates/base.tpl
@@ -23,6 +23,8 @@ distinctive_ring_tones.alert_info.8.ringer = 8
 features.caller_name_type_on_dialing = 1
 features.text_message.enable = 0
 features.text_message_popup.enable = 0
+features.config_dsskey_length = 1
+features.dnd.large_icon.enable = 1
 
 local_time.date_format = 2
 
@@ -88,8 +90,7 @@ static.usb.power.enable = 1
 {% for line_no, line in XX_sip_lines.iteritems() -%}
 {% if line -%}
 account.{{ line_no }}.enable = 1
-account.{{ line_no }}.label = {{ line['number']|d(line['display_name']) }}
-account.{{ line_no }}.display_name = {{ line['display_name'] }}
+account.{{ line_no }}.label = {{ line['display_name'] }}
 account.{{ line_no }}.auth_name = {{ line['auth_username'] }}
 account.{{ line_no }}.user_name = {{ line['username'] }}
 account.{{ line_no }}.password = {{ line['password'] }}
@@ -105,6 +106,11 @@ account.{{ line_no }}.alert_info_url_enable = 0
 account.{{ line_no }}.nat.udp_update_enable = 1
 account.{{ line_no }}.dtmf.type = {{ line['XX_dtmf_type']|d('2') }}
 account.{{ line_no }}.dtmf.info_type = 1
+{% if XX_sip_transport == '2' -%}
+account.{{ line_no }}.srtp_encryption = 2
+{% else -%}
+account.{{ line_no }}.srtp_encryption = 0
+{% endif %}
 
 account.{{ line_no }}.codec.g722.enable = 1
 account.{{ line_no }}.codec.g722_1c_48kpbs.enable = 1


### PR DESCRIPTION
Hello,

This PR brings several improvements to the Yealink plugin :

1. It properly adjusts account details display, with its name at the top of the screen, and its number in front of the DSS key.
2. It enlarges DSS key label zones, so that we can display larger labels.
3. It brings a bigger DND logo, so that we easily know DND has been left on.
4. It enables SRTP, if transport is TLS.

Thank you 👍

### Before :

![1_before](https://user-images.githubusercontent.com/106586925/171457808-c6bcf154-1ab0-4fbc-b175-8e1dc82664a3.jpg)

### After :

![2_after](https://user-images.githubusercontent.com/106586925/171457813-13d6a9da-ac34-4027-b24b-f17ef972c034.jpg)

![3_after](https://user-images.githubusercontent.com/106586925/171457816-aa41b60d-29cc-4f1f-b8af-0f239524f03f.jpg)

![4_after](https://user-images.githubusercontent.com/106586925/171457819-ee94c74c-d7cb-4547-b27d-6ec4efb7ce97.jpg)
