### PR TITLE
Snom enhancements

### DIFF
--- a/plugins/wazo-snom/10.1.101.11/plugin-info
+++ b/plugins/wazo-snom/10.1.101.11/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.7",
+    "version": "0.6.8",
     "description": "Plugin for Snom D3x5, D712, D717, D7x5 in version 10.1.101.11",
     "description_fr": "Greffon pour Snom D3x5, D712, D717, D7x5 en version 10.1.101.11",
     "capabilities": {

--- a/plugins/wazo-snom/common/common.py
+++ b/plugins/wazo-snom/common/common.py
@@ -128,6 +128,10 @@ class BaseSnomPlugin(StandardPlugin):
         u'RTP-out-of-band': u'off',
         u'SIP-INFO': u'sip_info_only'
     }
+    _SIP_TRANSPORT = {
+        u'udp': u'udp',
+        u'tls': u'tls'
+    }
     _XX_DICT_DEF = u'en'
     _XX_DICT = {
         u'en': {
@@ -258,6 +262,12 @@ class BaseSnomPlugin(StandardPlugin):
             cur_dtmf_mode = line.get(u'dtmf_mode', dtmf_mode)
             line[u'XX_user_dtmf_info'] = self._SIP_DTMF_MODE.get(cur_dtmf_mode, u'off')
 
+    def _add_sip_transport(self, raw_config):
+        transport = raw_config.get(u'sip_transport')
+        for line in raw_config[u'sip_lines'].itervalues():
+            cur_transport = line.get(u'transport', transport)
+            line[u'XX_sip_transport'] = self._SIP_TRANSPORT.get(cur_transport, u'udp')
+
     def _add_msgs_blocked(self, raw_config):
         msgs_blocked = ''
         for line_no, line in raw_config[u'sip_lines'].iteritems():
@@ -318,6 +328,7 @@ class BaseSnomPlugin(StandardPlugin):
         self._add_lang(raw_config)
         self._add_timezone(raw_config)
         self._add_user_dtmf_info(raw_config)
+        self._add_sip_transport(raw_config)
         self._add_msgs_blocked(raw_config)
         self._add_xivo_phonebook_url(raw_config)
         raw_config[u'XX_dict'] = self._gen_xx_dict(raw_config)

--- a/plugins/wazo-snom/common/common.py
+++ b/plugins/wazo-snom/common/common.py
@@ -130,6 +130,7 @@ class BaseSnomPlugin(StandardPlugin):
     }
     _SIP_TRANSPORT = {
         u'udp': u'udp',
+        u'tcp': u'tcp',
         u'tls': u'tls'
     }
     _XX_DICT_DEF = u'en'
@@ -263,10 +264,7 @@ class BaseSnomPlugin(StandardPlugin):
             line[u'XX_user_dtmf_info'] = self._SIP_DTMF_MODE.get(cur_dtmf_mode, u'off')
 
     def _add_sip_transport(self, raw_config):
-        transport = raw_config.get(u'sip_transport')
-        for line in raw_config[u'sip_lines'].itervalues():
-            cur_transport = line.get(u'transport', transport)
-            line[u'XX_sip_transport'] = self._SIP_TRANSPORT.get(cur_transport, u'udp')
+        raw_config[u'XX_sip_transport'] = self._SIP_TRANSPORT.get(raw_config.get(u'sip_transport'), u'udp')
 
     def _add_msgs_blocked(self, raw_config):
         msgs_blocked = ''

--- a/plugins/wazo-snom/common/templates/300.tpl
+++ b/plugins/wazo-snom/common/templates/300.tpl
@@ -4,7 +4,11 @@
 <fkey idx="0" context="1" perm="R">line</fkey>
 <fkey idx="1" context="2" perm="R">line</fkey>
 <fkey idx="2" context="active" perm="R">keyevent F_REDIAL</fkey>
+{% if XX_xivo_phonebook_url -%}
+<fkey idx="3" context="active" perm="R">none</fkey>
+{% else -%}
 <fkey idx="3" context="active" perm="R">keyevent F_ADR_BOOK</fkey>
+{% endif -%}
 <fkey idx="4" context="active" perm="R">transfer</fkey>
 <fkey idx="5" context="active" perm="R">keyevent F_MUTE</fkey>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/720.tpl
+++ b/plugins/wazo-snom/common/templates/720.tpl
@@ -3,6 +3,10 @@
 {% block gui_fkey1 %}{% endblock %}
 
 {% block settings_suffix %}
+{% if XX_xivo_phonebook_url -%}
+<gui_fkey1 perm="R">none</gui_fkey1>
+{% else -%}
 <gui_fkey1 perm="R">F_ADR_BOOK</gui_fkey1>
+{% endif -%}
 <gui_fkey4 perm="R">none</gui_fkey4>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/725.tpl
+++ b/plugins/wazo-snom/common/templates/725.tpl
@@ -3,6 +3,10 @@
 {% block gui_fkey1 %}{% endblock %}
 
 {% block settings_suffix %}
+{% if XX_xivo_phonebook_url -%}
+<gui_fkey1 perm="R">none</gui_fkey1>
+{% else -%}
 <gui_fkey1 perm="R">F_ADR_BOOK</gui_fkey1>
+{% endif -%}
 <gui_fkey4 perm="R">none</gui_fkey4>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/760.tpl
+++ b/plugins/wazo-snom/common/templates/760.tpl
@@ -3,6 +3,10 @@
 {% block gui_fkey1 %}{% endblock %}
 
 {% block settings_suffix %}
+{% if XX_xivo_phonebook_url -%}
+<gui_fkey1 perm="R">none</gui_fkey1>
+{% else -%}
 <gui_fkey1 perm="R">F_ADR_BOOK</gui_fkey1>
+{% endif -%}
 <gui_fkey4 perm="R">none</gui_fkey4>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/D735.tpl
+++ b/plugins/wazo-snom/common/templates/D735.tpl
@@ -3,6 +3,10 @@
 {% block gui_fkey1 %}{% endblock %}
 
 {% block settings_suffix %}
+{% if XX_xivo_phonebook_url -%}
+<gui_fkey1 perm="R">none</gui_fkey1>
+{% else -%}
 <gui_fkey1 perm="R">F_ADR_BOOK</gui_fkey1>
+{% endif -%}
 <gui_fkey4 perm="R">none</gui_fkey4>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/D745.tpl
+++ b/plugins/wazo-snom/common/templates/D745.tpl
@@ -3,6 +3,10 @@
 {% block gui_fkey1 %}{% endblock %}
 
 {% block settings_suffix %}
+{% if XX_xivo_phonebook_url -%}
+<gui_fkey1 perm="R">none</gui_fkey1>
+{% else -%}
 <gui_fkey1 perm="R">F_ADR_BOOK</gui_fkey1>
+{% endif -%}
 <gui_fkey4 perm="R">none</gui_fkey4>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/D765.tpl
+++ b/plugins/wazo-snom/common/templates/D765.tpl
@@ -3,6 +3,10 @@
 {% block gui_fkey1 %}{% endblock %}
 
 {% block settings_suffix %}
+{% if XX_xivo_phonebook_url -%}
+<gui_fkey1 perm="R">none</gui_fkey1>
+{% else -%}
 <gui_fkey1 perm="R">F_ADR_BOOK</gui_fkey1>
+{% endif -%}
 <gui_fkey4 perm="R">none</gui_fkey4>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/D785.tpl
+++ b/plugins/wazo-snom/common/templates/D785.tpl
@@ -3,6 +3,10 @@
 {% block gui_fkey1 %}{% endblock %}
 
 {% block settings_suffix %}
+{% if XX_xivo_phonebook_url -%}
+<gui_fkey1 perm="R">none</gui_fkey1>
+{% else -%}
 <gui_fkey1 perm="R">F_ADR_BOOK</gui_fkey1>
+{% endif -%}
 <gui_fkey4 perm="R">none</gui_fkey4>
 {% endblock %}

--- a/plugins/wazo-snom/common/templates/base.tpl
+++ b/plugins/wazo-snom/common/templates/base.tpl
@@ -34,8 +34,16 @@
 
     {% for line_no, line in sip_lines.iteritems() %}
     <user_active idx="{{ line_no }}" perm="R">on</user_active>
-    <user_idle_text idx="{{ line_no }}" perm="R">{{ line['display_name']|e }} {{ line['number'] }}</user_idle_text>
+    <user_idle_text idx="{{ line_no }}" perm="R">{{ line['display_name']|e }}</user_idle_text>
+    <user_idle_number idx="{{ line_no }}" perm="R">{{ line['number'] }}</user_idle_text>
     <user_host idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}</user_host>
+    {% if line['XX_sip_transport'] == 'tls' -%}
+    <user_outbound idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport=tls</user_outbound>
+    <user_srtp idx="{{ line_no }}" perm="R">on</user_srtp>
+    {% else -%}
+    <user_outbound idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }}</user_outbound>
+    <user_srtp idx="{{ line_no }}" perm="R">off</user_srtp>
+    {% endif %}
     <user_name idx="{{ line_no }}" perm="R">{{ line['username']|e }}</user_name>
     <user_pname idx="{{ line_no }}" perm="R">{{ line['auth_username']|e }}</user_pname>
     <user_pass idx="{{ line_no }}" perm="R">{{ line['password']|e }}</user_pass>
@@ -50,6 +58,13 @@
     <user_active idx="{{ line_no|int + 1 }}" perm="R">on</user_active>
     <user_idle_text idx="{{ line_no|int + 1 }}" perm="R">{{ line['display_name']|e }} {{ line['number'] }}</user_idle_text>
     <user_host idx="{{ line_no|int + 1 }}" perm="R">{{ line['backup_proxy_ip'] }}</user_host>
+    {% if line['XX_sip_transport'] == 'tls' -%}
+    <user_outbound idx="{{ line_no|int + 1 }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport=tls</user_outbound>
+    <user_srtp idx="{{ line_no|int + 1 }}" perm="R">on</user_srtp>
+    {% else -%}
+    <user_outbound idx="{{ line_no|int + 1 }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }}</user_outbound>
+    <user_srtp idx="{{ line_no|int + 1 }}" perm="R">off</user_srtp>
+    {% endif %}
     <user_name idx="{{ line_no|int + 1 }}" perm="R">{{ line['username']|e }}</user_name>
     <user_pname idx="{{ line_no|int + 1 }}" perm="R">{{ line['auth_username']|e }}</user_pname>
     <user_pass idx="{{ line_no|int + 1 }}" perm="R">{{ line['password']|e }}</user_pass>

--- a/plugins/wazo-snom/common/templates/base.tpl
+++ b/plugins/wazo-snom/common/templates/base.tpl
@@ -37,11 +37,10 @@
     <user_idle_text idx="{{ line_no }}" perm="R">{{ line['display_name']|e }}</user_idle_text>
     <user_idle_number idx="{{ line_no }}" perm="R">{{ line['number'] }}</user_idle_text>
     <user_host idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}</user_host>
-    {% if line['XX_sip_transport'] == 'tls' -%}
-    <user_outbound idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport=tls</user_outbound>
+    <user_outbound idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport={{ XX_sip_transport }}</user_outbound>
+    {% if XX_sip_transport == 'tls' -%}
     <user_srtp idx="{{ line_no }}" perm="R">on</user_srtp>
     {% else -%}
-    <user_outbound idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }}</user_outbound>
     <user_srtp idx="{{ line_no }}" perm="R">off</user_srtp>
     {% endif %}
     <user_name idx="{{ line_no }}" perm="R">{{ line['username']|e }}</user_name>
@@ -58,11 +57,10 @@
     <user_active idx="{{ line_no|int + 1 }}" perm="R">on</user_active>
     <user_idle_text idx="{{ line_no|int + 1 }}" perm="R">{{ line['display_name']|e }} {{ line['number'] }}</user_idle_text>
     <user_host idx="{{ line_no|int + 1 }}" perm="R">{{ line['backup_proxy_ip'] }}</user_host>
-    {% if line['XX_sip_transport'] == 'tls' -%}
-    <user_outbound idx="{{ line_no|int + 1 }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport=tls</user_outbound>
+    <user_outbound idx="{{ line_no|int + 1 }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport={{ XX_sip_transport }}</user_outbound>
+    {% if XX_sip_transport == 'tls' -%}
     <user_srtp idx="{{ line_no|int + 1 }}" perm="R">on</user_srtp>
     {% else -%}
-    <user_outbound idx="{{ line_no|int + 1 }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }}</user_outbound>
     <user_srtp idx="{{ line_no|int + 1 }}" perm="R">off</user_srtp>
     {% endif %}
     <user_name idx="{{ line_no|int + 1 }}" perm="R">{{ line['username']|e }}</user_name>

--- a/plugins/wazo-snom/common/var/tftpboot/snom-general.xml
+++ b/plugins/wazo-snom/common/var/tftpboot/snom-general.xml
@@ -33,8 +33,6 @@
     <cw_dialtone perm="R">off</cw_dialtone>
 
     <network_id_port perm="R">5060</network_id_port>
-    <tls_listen perm="R">on</tls_listen>
-    <sip_tls_listen_port perm="R">5061</sip_tls_listen_port>
 
     <answer_after_policy perm="R">idle</answer_after_policy>
 

--- a/plugins/wazo-snom/common/var/tftpboot/snom-general.xml
+++ b/plugins/wazo-snom/common/var/tftpboot/snom-general.xml
@@ -4,14 +4,14 @@
     <!-- auto_reboot must be at the top of the file to be effective -->
     <auto_reboot_on_setting_change perm="R">on</auto_reboot_on_setting_change>
 
-    <provisioning_order perm="R">dhcp:stop</provisioning_order>
+    <provisioning_order perm="R">dhcp:stop redirection:stop</provisioning_order>
 
     <!-- the "perm" attribute for admin_mode must be "RW", else the admin
          can't enter admin mode on the phone because the admin_mode value
          is read only -->
     <admin_mode perm="RW">off</admin_mode>
 
-    <retry_after_failed_register perm="R">120</retry_after_failed_register>
+    <retry_after_failed_register perm="R">5:60</retry_after_failed_register>
 
     <date_us_format perm="R">off</date_us_format>
     <time_24_format perm="R">on</time_24_format>
@@ -33,6 +33,8 @@
     <cw_dialtone perm="R">off</cw_dialtone>
 
     <network_id_port perm="R">5060</network_id_port>
+    <tls_listen perm="R">on</tls_listen>
+    <sip_tls_listen_port perm="R">5061</sip_tls_listen_port>
 
     <answer_after_policy perm="R">idle</answer_after_policy>
 
@@ -52,22 +54,6 @@
     <user_active idx="10" perm="R">off</user_active>
     <user_active idx="11" perm="R">off</user_active>
     <user_active idx="12" perm="R">off</user_active>
-
-    <!-- Set user_srtp to off until we have TLS/SRTP support in the plugin
-         since setting it to on seems to cause some compatibility issue with
-         asterisk 1.8. See http://forum.snom.com/index.php?showtopic=6665 -->
-    <user_srtp idx="1" perm="R">off</user_srtp>
-    <user_srtp idx="2" perm="R">off</user_srtp>
-    <user_srtp idx="3" perm="R">off</user_srtp>
-    <user_srtp idx="4" perm="R">off</user_srtp>
-    <user_srtp idx="5" perm="R">off</user_srtp>
-    <user_srtp idx="6" perm="R">off</user_srtp>
-    <user_srtp idx="7" perm="R">off</user_srtp>
-    <user_srtp idx="8" perm="R">off</user_srtp>
-    <user_srtp idx="9" perm="R">off</user_srtp>
-    <user_srtp idx="10" perm="R">off</user_srtp>
-    <user_srtp idx="11" perm="R">off</user_srtp>
-    <user_srtp idx="12" perm="R">off</user_srtp>
 
     <!-- http://wiki.snom.com/Interoperability/PBX/Asterisk-->
     <call_completion perm="R">off</call_completion>


### PR DESCRIPTION
Hello,

This PR brings several improvements to the Yealink plugin :

1. It properly adjusts account details display, replacing useless SIP user ID with the extension number.
2. It disable local phonebook if remote phonebook is available (so that we're sure it's properly used).
3. It adjusts `retry_after_failed_register`, making devices to retry faster on their first retries, as some SIP-TLS configured devices systematically wait 2 minutes before registering. Adjusting `retry_after_failed_register` like in this PR solves this issue.
4. It ajusts `provisioning_order`, allowing to provision Snom devices manually. This modification does not break DHCP provisionning, it simply allows devices to provision manually if they do not receive any provisioning option from DHCP.
5. It enables SIP-TLS and SRTP on a per-line basis.

Thank you 👍

### Before :

![1_before](https://user-images.githubusercontent.com/106586925/171600632-60d341cb-4b55-4001-802c-e539059aadd2.jpg)

### After :

![2_after](https://user-images.githubusercontent.com/106586925/171600655-f5060e02-c937-44a8-bc41-4fe70654bf2a.jpg)

