### PR TITLE
Gigaset N720 enhancements

### DIFF
--- a/plugins/wazo-gigaset/N720/entry.py
+++ b/plugins/wazo-gigaset/N720/entry.py
@@ -7,8 +7,8 @@ execfile_('common.py', common)
 
 
 MODEL_VERSIONS = {
-    u'N720 DM PRO': u'70.111.00.000.000',
-    u'N720 IP PRO': u'70.111.00.000.000',
+    u'N720 DM PRO': u'70.117.00.000.000',
+    u'N720 IP PRO': u'70.117.00.000.000',
 }
 
 

--- a/plugins/wazo-gigaset/N720/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/N720/pkgs/pkgs.db
@@ -1,7 +1,7 @@
 [pkg_N720-fw]
 description: Firmware for Gigaset N720 IP PRO
 description_fr: Micrologiciel pour Gigaset N720 IP PRO
-version: 70.111.00.000.000
+version: 70.117.00.000.000
 files: N720-fw
 install: gigasetn720-fw
 
@@ -10,7 +10,7 @@ a-b: unzip $FILE1
 b-c: cp */*.bin Gigaset/
 
 [file_N720-fw]
-filename: N720_SW111.zip
-url: https://teamwork.gigaset.com/gigawiki/download/attachments/759175882/N720_SW_111.zip?version=1&modificationDate=1523875534000&api=v2&download=true
-size: 2107221
-sha1sum: d1f4bfa552bf5abdf98f0eead1aeb3f34842e8c6
+filename: N720_SW117.zip
+url: https://teamwork.gigaset.com/gigawiki/download/attachments/1298697904/N720_SW_117.zip?version=1&modificationDate=1646146386000&api=v2&download=true
+size: 2118993
+sha1sum: 6e51f84e64a432e92d973988d66fe6634ca2197d

--- a/plugins/wazo-gigaset/N720/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/N720/pkgs/pkgs.db
@@ -7,8 +7,7 @@ install: gigasetn720-fw
 
 [install_gigasetn720-fw]
 a-b: unzip $FILE1
-b-c: cp */einsteiniwu111_70.bin Gigaset/server_einstein_iwu111.bin
-b-d: cp */sat*.bin Gigaset/
+b-c: cp */*.bin Gigaset/
 
 [file_N720-fw]
 filename: N720_SW111.zip

--- a/plugins/wazo-gigaset/N720/plugin-info
+++ b/plugins/wazo-gigaset/N720/plugin-info
@@ -3,7 +3,7 @@
     "description": "Plugin for Gigaset N720 IP/DM PRO.",
     "description_fr": "Greffon pour Gigaset N720 IP/DM PRO.",
     "capabilities": {
-        "Gigaset, N720 IP/DM PRO, 70.111": {
+        "Gigaset, N720 IP/DM PRO, 70.117": {
             "lines": 100,
             "high_availability": false,
             "function_keys": 0,

--- a/plugins/wazo-gigaset/N720/plugin-info
+++ b/plugins/wazo-gigaset/N720/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.12",
+    "version": "0.1.13",
     "description": "Plugin for Gigaset N720 IP/DM PRO.",
     "description_fr": "Greffon pour Gigaset N720 IP/DM PRO.",
     "capabilities": {

--- a/plugins/wazo-gigaset/N720/templates/base.tpl
+++ b/plugins/wazo-gigaset/N720/templates/base.tpl
@@ -9,8 +9,8 @@
         <MAC_ADDRESS value="{{ XX_mac_addr }}"/>
         <PROFILE_NAME class="string" value="N720"/>
     {%- if http_port %}
-        <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/einsteiniwu111_70.bin?mac={{ XX_mac_addr }}&server_einstein_iwu111.bin"'/>
-        <S_SPECIAL_DATA_SRV_SAT class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/sat7111100000000.bin?mac={{ XX_mac_addr }}&sat7111100000000.bin"'/>
+        <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/einsteiniwu117_70.bin?mac={{ XX_mac_addr }}&server_einstein_iwu117.bin"'/>
+        <S_SPECIAL_DATA_SRV_SAT class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/sat7111700000000.bin?mac={{ XX_mac_addr }}&sat7111700000000.bin"'/>
         <SYMB_ITEM ID="BS_IP_Data.KindOfPlannedUpdate" class="symb_item" value="1"/>
         <SYMB_ITEM ID="BS_IP_Data.PlannedUpdateTime" class="symb_item" value="0x648"/>
     {%- endif %}

--- a/plugins/wazo-gigaset/N720/templates/base.tpl
+++ b/plugins/wazo-gigaset/N720/templates/base.tpl
@@ -42,6 +42,7 @@
 
     <!-- Local settings - Data -->
         <SYMB_ITEM ID="BS_IP_Data.aucS_NETWORK_DEVICENAME[%]" class="symb_item" value='"N720-DM-PRO"'/>
+        <SYMB_ITEM ID="BS_RAP.astRAPServices[1].ActivateService" class="symb_item" value="0"/>
     {%- if http_port %}
         <SYMB_ITEM ID="BS_IP_Data.aucS_DATA_SERVER[%]" class="symb_item" value='"http://{{ ip }}:{{ http_port }}"'/>
     {%- endif %}
@@ -186,7 +187,7 @@
     {%- if sip_lines %}
         {%- for line_no, line in sip_lines.iteritems() %}
         {%- set lnb = line_no|int() - 1 %}
-        <SYMB_ITEM ID="BS_VOIP_Data.astVoipAccounts[{{ lnb }}].aucS_SIP_DISPLAYNAME[0]" class="symb_item" value='"{{ line['number'] }} | {{ line['display_name'] }}"'/>
+        <SYMB_ITEM ID="BS_VOIP_Data.astVoipAccounts[{{ lnb }}].aucS_SIP_DISPLAYNAME[0]" class="symb_item" value='"{{ line['number'] }} {{ line['display_name'] }}"'/>
         <SYMB_ITEM ID="BS_VOIP_Data.astVoipAccounts[{{ lnb }}].aucS_SIP_LOGIN_ID[0]" class="symb_item" value='"{{ line['auth_username']|d(line['username']) }}"'/>
         <SYMB_ITEM ID="BS_VOIP_Data.astVoipAccounts[{{ lnb }}].aucS_SIP_PASSWORD[0]" class="symb_item" value='"{{ line['auth_password']|d(line['password']) }}"'/>
         <SYMB_ITEM ID="BS_VOIP_Data.astVoipAccounts[{{ lnb }}].aucS_SIP_USER_ID[0]" class="symb_item" value='"{{ line['auth_username']|d(line['username']) }}"'/>

--- a/plugins/wazo-gigaset/N720/templates/base.tpl
+++ b/plugins/wazo-gigaset/N720/templates/base.tpl
@@ -43,6 +43,7 @@
     <!-- Local settings - Data -->
         <SYMB_ITEM ID="BS_IP_Data.aucS_NETWORK_DEVICENAME[%]" class="symb_item" value='"N720-DM-PRO"'/>
         <SYMB_ITEM ID="BS_RAP.astRAPServices[1].ActivateService" class="symb_item" value="0"/>
+        <SYMB_ITEM ID="BS_CUSTOM.WebUIPassword" class="symb_item" value='"{{ admin_password }}"'/>
     {%- if http_port %}
         <SYMB_ITEM ID="BS_IP_Data.aucS_DATA_SERVER[%]" class="symb_item" value='"http://{{ ip }}:{{ http_port }}"'/>
     {%- endif %}

--- a/plugins/wazo-gigaset/N720/templates/base.tpl
+++ b/plugins/wazo-gigaset/N720/templates/base.tpl
@@ -9,7 +9,7 @@
         <MAC_ADDRESS value="{{ XX_mac_addr }}"/>
         <PROFILE_NAME class="string" value="N720"/>
     {%- if http_port %}
-        <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/server_einstein_iwu111.bin?mac={{ XX_mac_addr }}&server_einstein_iwu111.bin"'/>
+        <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/einsteiniwu111_70.bin?mac={{ XX_mac_addr }}&server_einstein_iwu111.bin"'/>
         <S_SPECIAL_DATA_SRV_SAT class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/sat7111100000000.bin?mac={{ XX_mac_addr }}&sat7111100000000.bin"'/>
         <SYMB_ITEM ID="BS_IP_Data.KindOfPlannedUpdate" class="symb_item" value="1"/>
         <SYMB_ITEM ID="BS_IP_Data.PlannedUpdateTime" class="symb_item" value="0x648"/>

--- a/plugins/wazo-gigaset/N720/templates/base.tpl
+++ b/plugins/wazo-gigaset/N720/templates/base.tpl
@@ -8,14 +8,12 @@
     -->
         <MAC_ADDRESS value="{{ XX_mac_addr }}"/>
         <PROFILE_NAME class="string" value="N720"/>
-    {# Disable firmware upgrade temporarily because of issues
     {%- if http_port %}
-        <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/server_einstein_iwu111.bin"'/>
-        <S_SPECIAL_DATA_SRV_SAT class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/sat7111100000000.bin"'/>
+        <S_SPECIAL_DATA_SRV_IWU class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/server_einstein_iwu111.bin?mac={{ XX_mac_addr }}&server_einstein_iwu111.bin"'/>
+        <S_SPECIAL_DATA_SRV_SAT class="string" value='"http://{{ ip }}:{{ http_port }}/Gigaset/sat7111100000000.bin?mac={{ XX_mac_addr }}&sat7111100000000.bin"'/>
+        <SYMB_ITEM ID="BS_IP_Data.KindOfPlannedUpdate" class="symb_item" value="1"/>
+        <SYMB_ITEM ID="BS_IP_Data.PlannedUpdateTime" class="symb_item" value="0x648"/>
     {%- endif %}
-    #}
-    <S_SPECIAL_DATA_SRV_IWU class="string" value=""/>
-    <S_SPECIAL_DATA_SRV_SAT class="string" value=""/>
     <!-- NetDirectory settings -->
     {%- if XX_xivo_phonebook_url %}
         <SYMB_ITEM ID="BS_XML_Netdirs.aucAvailableNetdirs[%]" class="symb_item" value="0x2a"/>


### PR DESCRIPTION
Hi,

This PR brings some enhancements to Gigaset N720 :

1. It enables firmware updates. I found a trick to make the firmware link compliant with what N720 expects (it must end with the binary name), while keeping it served by Wazo itself. Look at the links for technical workaround, self explanatory :) Good news is that I'll be able to replicate this for N510 (see #142) 👍
2. It disables Gigaset.net info/news by default. Privacy is best.
3. It saves some characters on display name, characters are counted on these DECT screens...
4. It updates firmware to last version (tested, no issue with standard features).
5. It properly sets admin password.

Thank you 👍 