### PR TITLE
yealink remote controll

### DIFF
--- a/plugins/wazo-yealink/v83/templates/base.tpl
+++ b/plugins/wazo-yealink/v83/templates/base.tpl
@@ -21,6 +21,8 @@ distinctive_ring_tones.alert_info.7.ringer = 7
 distinctive_ring_tones.alert_info.8.ringer = 8
 
 features.caller_name_type_on_dialing = 1
+features.action_uri_limit_ip = {{ ip }}
+features.show_action_uri_option = 0
 
 local_time.date_format = 2
 

--- a/plugins/wazo-yealink/v86/templates/base.tpl
+++ b/plugins/wazo-yealink/v86/templates/base.tpl
@@ -25,6 +25,8 @@ features.text_message.enable = 0
 features.text_message_popup.enable = 0
 features.config_dsskey_length = 1
 features.dnd.large_icon.enable = 1
+features.action_uri_limit_ip = {{ ip }}
+features.show_action_uri_option = 0
 
 local_time.date_format = 2
 


### PR DESCRIPTION
Allow the ipbx ip address to do remote control and disable the confirmation on the phone.

Yealink documentation of the feature : https://support.yealink.com/en/portal/knowledge/show?id=4178499082ef79a8bd59639f

A example of what can be done with this feature enabled : https://support.yealink.com/en/portal/knowledge/show?id=9cc44e52868384ce4c623437