### PR TITLE
Solve bug introduced in #136

### DIFF
--- a/plugins/wazo-snom/10.1.101.11/pkgs/pkgs.db
+++ b/plugins/wazo-snom/10.1.101.11/pkgs/pkgs.db
@@ -84,7 +84,6 @@ install: snom-fw
 
 [install_snom-fw]
 a-b: cp $FILE1 firmware/
-b-c: touch -c firmware/$FILE1
 
 [file_uxmc-fw]
 url: https://downloads.snom.com/fw/d7c/snomD7C-1.1.1-r.bin

--- a/plugins/wazo-snom/10.1.101.11/plugin-info
+++ b/plugins/wazo-snom/10.1.101.11/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.9",
+    "version": "0.7.0",
     "description": "Plugin for Snom D3x5, D712, D717, D7x5 in version 10.1.101.11",
     "description_fr": "Greffon pour Snom D3x5, D712, D717, D7x5 en version 10.1.101.11",
     "capabilities": {


### PR DESCRIPTION
Hello,

This PR solves a bug introduced in #136, during plugin installation :
```
2022-07-04 16:54:29,721 [28336] (ERROR) (provd.app): Error while loading plugin wazo-snom-10.1.101.11
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/provd/app.py", line 824, in _pg_load
    self.pg_mgr.load(id, gen_cfg, spec_cfg)
  File "/usr/lib/python2.7/dist-packages/provd/plugins.py", line 1134, in load
    plugin = obj(self._app, plugin_dir, gen_cfg, spec_cfg)
  File "/var/lib/wazo-provd/plugins/wazo-snom-10.1.101.11/common.py", line 153, in __init__
    fetchfw_helper = FetchfwPluginHelper(plugin_dir, downloaders)
  File "/usr/lib/python2.7/dist-packages/provd/plugins.py", line 554, in __init__
    self._pkg_mgr = self._new_pkg_mgr(downloaders, filter_builder)
  File "/usr/lib/python2.7/dist-packages/provd/plugins.py", line 572, in _new_pkg_mgr
    pkg_builder)
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/storage.py", line 386, in __init__
    self._load_pkgs()
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/storage.py", line 393, in _load_pkgs
    self._pkgs = self._create_pkg(config, pkg_sections, remote_files, install_mgr_factories)
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/storage.py", line 455, in _create_pkg
    pkg = self._pkg_builder.build_installable_pkg(config, section, pkg_id, remote_files, install_mgr_factories)
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/storage.py", line 280, in build_installable_pkg
    pkg_install_mgr = install_mgr_factory.new_install_mgr(src_node, local_vars)
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/storage.py", line 188, in new_install_mgr
    filter_obj = self._filter_builder.build_node(tokens)
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/storage.py", line 144, in build_node
    raise ValueError("unknown node type %s" % type)
ValueError: unknown node type touch
```

We finally do not need `touch` command, as `cp` command right above already modifies the modification date of the file, which is what we want here, perfect.

Thank you, and sorry for the inconveniences...