### PR TITLE
Snom, Yealink, allow autoprov with SIP TLS

### DIFF
--- a/plugins/wazo-snom/10.1.101.11/plugin-info
+++ b/plugins/wazo-snom/10.1.101.11/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Plugin for Snom D3x5, D712, D717, D7x5 in version 10.1.101.11",
     "description_fr": "Greffon pour Snom D3x5, D712, D717, D7x5 en version 10.1.101.11",
     "capabilities": {

--- a/plugins/wazo-snom/common/templates/base.tpl
+++ b/plugins/wazo-snom/common/templates/base.tpl
@@ -62,7 +62,7 @@
     <user_idle_text idx="{{ line_no|int + 1 }}" perm="R">{{ line['display_name']|e }} {{ line['number'] }}</user_idle_text>
     <user_host idx="{{ line_no|int + 1 }}" perm="R">{{ line['backup_proxy_ip'] }}</user_host>
     <user_outbound idx="{{ line_no|int + 1 }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport={{ XX_sip_transport }}</user_outbound>
-    {% if XX_sip_transport == 'tls' -%}
+    {% if XX_sip_transport == 'tls' and line['number'] != 'autoprov' -%}
     <user_srtp idx="{{ line_no|int + 1 }}" perm="R">on</user_srtp>
     {% else -%}
     <user_srtp idx="{{ line_no|int + 1 }}" perm="R">off</user_srtp>

--- a/plugins/wazo-snom/common/templates/base.tpl
+++ b/plugins/wazo-snom/common/templates/base.tpl
@@ -40,7 +40,7 @@
     <user_idle_number idx="{{ line_no }}" perm="R">{{ line['number'] }}</user_idle_text>
     <user_host idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}</user_host>
     <user_outbound idx="{{ line_no }}" perm="R">{{ line['proxy_ip'] }}:{{ line['proxy_port'] }};transport={{ XX_sip_transport }}</user_outbound>
-    {% if XX_sip_transport == 'tls' -%}
+    {% if XX_sip_transport == 'tls' and line['number'] != 'autoprov' -%}
     <user_srtp idx="{{ line_no }}" perm="R">on</user_srtp>
     {% else -%}
     <user_srtp idx="{{ line_no }}" perm="R">off</user_srtp>

--- a/plugins/wazo-yealink/v86/plugin-info
+++ b/plugins/wazo-yealink/v86/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "Plugin for Yealink for CP920, T27G, T3X, T4X and T5X series in version 86.",
     "description_fr": "Greffon pour Yealink pour les series CP920, T27G, T3X, T4X et T5X en version 86.",
     "vendor" : "Yealink",

--- a/plugins/wazo-yealink/v86/templates/base.tpl
+++ b/plugins/wazo-yealink/v86/templates/base.tpl
@@ -106,7 +106,7 @@ account.{{ line_no }}.alert_info_url_enable = 0
 account.{{ line_no }}.nat.udp_update_enable = 1
 account.{{ line_no }}.dtmf.type = {{ line['XX_dtmf_type']|d('2') }}
 account.{{ line_no }}.dtmf.info_type = 1
-{% if XX_sip_transport == '2' -%}
+{% if XX_sip_transport == '2' and line['number'] != 'autoprov' -%}
 account.{{ line_no }}.srtp_encryption = 2
 {% else -%}
 account.{{ line_no }}.srtp_encryption = 0


### PR DESCRIPTION
Hello,

When a device is connected to the stack, for the first time, an _autoprov_ configuration template is generated.

There's no problem if this template uses SIP TLS, device will properly reach the stack when provisioning using the  `Provision Extension` method.

However, SRTP can't be used here, because _autoprov_ stack SIP template has it disabled (for good reasons *).

Let's then disable SRTP when in _autoprov_ mode, for both SIP TLS validated plugin ; Snom & Yealink.

Thx 👍

BTW, while here, would really be nice for the _autoprov_ mode to inherit from the _global_ SIP template, so that it would really help for example in NATed environment etc... (see Wazo ticket #5571 / #6066).

(*) Note that even if _autoprov_ mode would inherit from the _global_ SIP template, we would not be able to enable SRTP there (`media_encryption = sdes`), because then it would break provisioning using the  `Provision Extension` method for devices not supporting SRTP.