### PR TITLE
Yealink, add CP920 firmware

### DIFF
--- a/plugins/wazo-yealink/v86/entry.py
+++ b/plugins/wazo-yealink/v86/entry.py
@@ -45,6 +45,7 @@ COMMON_FILES = [
     ('y000000000066.cfg', u'T46S(T48S,T42S,T41S)-66.86.0.15.rom', 'model.tpl'),
     ('y000000000067.cfg', u'T46S(T48S,T42S,T41S)-66.86.0.15.rom', 'model.tpl'),
     ('y000000000068.cfg', u'T46S(T48S,T42S,T41S)-66.86.0.15.rom', 'model.tpl'),
+    ('y000000000078.cfg', u'CP920-78.86.0.15.rom', 'model.tpl'),
     ('y000000000108.cfg', u'T46U(T43U,T46U,T41U,T48U,T42U)-108.86.0.45(20211130).rom', 'model.tpl'),
     ('y000000000123.cfg', u'T31(T30,T30P,T31G,T31P,T33P,T33G)-124.86.0.40.rom', 'model.tpl'),
     ('y000000000124.cfg', u'T31(T30,T30P,T31G,T31P,T33P,T33G)-124.86.0.40.rom', 'model.tpl'),

--- a/plugins/wazo-yealink/v86/plugin-info
+++ b/plugins/wazo-yealink/v86/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Plugin for Yealink for CP920, T27G, T3X, T4X and T5X series in version 86.",
     "description_fr": "Greffon pour Yealink pour les series CP920, T27G, T3X, T4X et T5X en version 86.",
     "vendor" : "Yealink",


### PR DESCRIPTION
Hi,

Yealink CP920 firmware is declared in `pkgs.db`, but not pushed up to the device.
Let's then fix this.

Thank you 👍