### PR TITLE
Gigaset, add support for N670 IP PRO

### DIFF
--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
@@ -1,0 +1,310 @@
+"""
+Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Common code shared by the various wazo-gigaset plugins.
+"""
+from __future__ import annotations
+
+import os
+import logging
+import re
+import time
+from typing import Dict, Optional
+
+from provd import (
+    plugins,
+    synchronize,
+    tzinform,
+)
+
+from provd.devices.pgasso import BasePgAssociator, DeviceSupport
+from provd.plugins import StandardPlugin, TemplatePluginHelper, FetchfwPluginHelper
+from provd.servers.http import HTTPNoListingFileService
+from provd.servers.http_site import Request
+from provd.devices.ident import RequestType
+from provd.util import norm_mac, format_mac
+from twisted.internet import defer
+
+logger = logging.getLogger('plugin.wazo-gigaset')
+
+VENDOR = 'Gigaset'
+
+
+class GigasetHTTPDeviceInfoExtractor:
+
+    _UA_REGEX = re.compile(
+        r'^"?(Gigaset )?(?P<model>[\w\s]+)\/(?P<version>(?:\w{2,3}\.){3,4}\w{1,3})(?:\+.+)?;'
+        r'(?P<mac>[0-9A-F]{12})?(;Handset=\d+)?"?$'
+    )
+
+    def extract(self, request: Request, request_type: RequestType):
+        return defer.succeed(self._do_extract(request))
+
+    def _do_extract(self, request: Request):
+        dev_info = {}
+
+        ua = request.getHeader(b'User-Agent')
+        if ua:
+            dev_info.update(self._extract_from_ua(ua.decode('ascii')))
+
+        return dev_info
+
+    def _extract_from_ua(self, ua: str):
+        # HTTP User-Agent:
+        # "Gigaset N870 IP PRO/83.V2.11.0+build.a546b91;7C2F80E0D605"
+        m = self._UA_REGEX.search(ua)
+        dev_info = {}
+        if m:
+            dev_info = {
+                'vendor': VENDOR,
+                'model': m.group('model'),
+                'version': m.group('version'),
+            }
+            if 'mac' in m.groupdict():
+                dev_info['mac'] = norm_mac(m.group('mac'))
+
+        return dev_info
+
+
+class BaseGigasetPgAssociator(BasePgAssociator):
+    def __init__(self, models):
+        self._models = models
+
+    def _do_associate(
+        self, vendor: str, model: Optional[str], version: Optional[str]
+    ) -> DeviceSupport:
+        if vendor == VENDOR:
+            if model in self._models:
+                if version == self._models[model]:
+                    return DeviceSupport.EXACT
+                return DeviceSupport.COMPLETE
+            return DeviceSupport.UNKNOWN
+        return DeviceSupport.IMPROBABLE
+
+
+class BaseGigasetPlugin(StandardPlugin):
+    _ENCODING = 'UTF-8'
+
+    _SIP_DTMF_MODE = {
+        'RTP-in-band': '1',
+        'RTP-out-of-band': '2',
+        'SIP-INFO': '4',
+    }
+    _SIP_TRANSPORT = {
+        'udp': '1',
+        'tcp': '2',
+        'tls': '3',
+    }
+
+    _VALID_TZ_GIGASET = {
+        'Pacific/Honolulu',
+        'America/Anchorage',
+        'America/Los_Angeles',
+        'America/Denver',
+        'America/Chicago',
+        'America/New_York',
+        'America/Caracas',
+        'America/Sao_Paulo',
+        'Europe/Belfast',
+        'Europe/Dublin',
+        'Europe/Guernsey',
+        'Europe/Isle_of_Man',
+        'Europe/Jersey',
+        'Europe/Lisbon',
+        'Europe/London',
+        'Greenwich',
+        'Europe/Amsterdam',
+        'Europe/Andorra',
+        'Europe/Belgrade',
+        'Europe/Berlin',
+        'Europe/Bratislava',
+        'Europe/Brussels',
+        'Europe/Budapest',
+        'Europe/Busingen',
+        'Europe/Copenhagen',
+        'Europe/Gibraltar',
+        'Europe/Ljubljana',
+        'Europe/Luxembourg',
+        'Europe/Madrid',
+        'Europe/Malta',
+        'Europe/Monaco',
+        'Europe/Oslo',
+        'Europe/Paris',
+        'Europe/Podgorica',
+        'Europe/Prague',
+        'Europe/Rome',
+        'Europe/San_Marino',
+        'Europe/Sarajevo',
+        'Europe/Skopje',
+        'Europe/Stockholm',
+        'Europe/Tirane',
+        'Europe/Vaduz',
+        'Europe/Vatican',
+        'Europe/Vienna',
+        'Europe/Warsaw',
+        'Europe/Zagreb',
+        'Europe/Zurich',
+        'Africa/Cairo',
+        'Europe/Athens',
+        'Europe/Bucharest',
+        'Europe/Chisinau',
+        'Europe/Helsinki',
+        'Europe/Kaliningrad',
+        'Europe/Kiev',
+        'Europe/Mariehamn',
+        'Europe/Nicosia',
+        'Europe/Riga',
+        'Europe/Sofia',
+        'Europe/Tallinn',
+        'Europe/Tiraspol',
+        'Europe/Uzhgorod',
+        'Europe/Vilnius',
+        'Europe/Zaporozhye',
+        'Europe/Istanbul',
+        'Europe/Kirov',
+        'Europe/Minsk',
+        'Europe/Moscow',
+        'Europe/Simferopol',
+        'Europe/Volgograd',
+        'Asia/Dubai',
+        'Europe/Astrakhan',
+        'Europe/Samara',
+        'Europe/Ulyanovsk',
+        'Asia/Karachi',
+        'Asia/Dhaka',
+        'Asia/Hong_Kong',
+        'Asia/Tokyo',
+        'Australia/Adelaide',
+        'Australia/Darwin',
+        'Australia/Brisbane',
+        'Australia/Sydney',
+        'Pacific/Noumea',
+    }
+
+    _FALLBACK_TZ = {
+        (-3, 0): 'America/Sao_Paulo',
+        (-4, 0): 'America/New_York',
+        (-5, 0): 'America/Chicago',
+        (-6, 0): 'America/Denver',
+        (-7, 0): 'America/Los_Angeles',
+        (-8, 0): 'America/Anchorage',
+        (-10, 0): 'Pacific/Honolulu',
+        (0, 0): 'Greenwich',
+        (1, 0): 'Europe/London',
+        (2, 0): 'Europe/Paris',
+        (3, 0): 'Europe/Moscow',
+        (4, 0): 'Asia/Dubai',
+        (5, 0): 'Asia/Karachi',
+        (6, 0): 'Asia/Dhaka',
+        (8, 0): 'Asia/Hong_Kong',
+        (9, 0): 'Asia/Tokyo',
+        (9, 3): 'Australia/Adelaide',
+        (10, 0): 'Australia/Sydney',
+        (11, 0): 'Pacific/Noumea',
+    }
+    _SENSITIVE_FILENAME_REGEX = re.compile(r'^[0-9a-f]{12}\.xml$')
+
+    def __init__(self, app, plugin_dir, gen_cfg, spec_cfg):
+        super().__init__(app, plugin_dir, gen_cfg, spec_cfg)
+        self._app = app
+
+        self._tpl_helper = TemplatePluginHelper(plugin_dir)
+        downloaders = FetchfwPluginHelper.new_downloaders(gen_cfg.get('proxies'))
+        fetchfw_helper = FetchfwPluginHelper(plugin_dir, downloaders)
+
+        self.services = fetchfw_helper.services()
+        self.http_service = HTTPNoListingFileService(self._tftpboot_dir)
+
+    http_dev_info_extractor = GigasetHTTPDeviceInfoExtractor()
+
+    def _check_device(self, device):
+        if 'ip' not in device:
+            raise Exception('IP address needed for Gigaset configuration')
+
+    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+        # Return the device specific filename (not pathname) of device
+        formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
+        return f'{formatted_mac}.xml'
+
+    def _add_phonebook(self, raw_config):
+        uuid_format = '{scheme}://{hostname}:{port}/0.1/directories/lookup/{profile}/gigaset/{user_uuid}?'  # noqa: E501
+        plugins.add_xivo_phonebook_url_from_format(raw_config, uuid_format)
+
+    def _fix_timezone(self, raw_config):
+        timezone = raw_config.get('timezone', 'Greenwich')
+        if timezone not in self._VALID_TZ_GIGASET:
+            tz_db = tzinform.TextTimezoneInfoDB()
+            tz_info = tz_db.get_timezone_info(timezone)['utcoffset'].as_hms
+            offset_hour = tz_info[0]
+            offset_minutes = tz_info[1]
+            raw_config['timezone'] = self._FALLBACK_TZ[(offset_hour, offset_minutes)]
+
+    def _add_xx_vars(self, device, raw_config):
+        raw_config['XX_epoch'] = int(time.time())
+        self._fix_timezone(raw_config)
+
+    def _add_voip_providers(self, raw_config):
+        voip_providers = dict()
+        provider_id = 0
+        sip_lines = raw_config.get('sip_lines')
+        dtmf_mode = raw_config.get('sip_dtmf_mode', '1')
+        sip_transport = self._SIP_TRANSPORT.get(raw_config.get('sip_transport', '1'))
+        if sip_lines:
+            for line in sip_lines.values():
+                proxy_ip = line.get('proxy_ip')
+                proxy_port = line.get('proxy_port', 5060)
+                line_dtmf_mode = self._SIP_DTMF_MODE.get(
+                    line.get('dtmf_mode', dtmf_mode)
+                )
+                if (proxy_ip, proxy_port) not in voip_providers:
+                    provider = {
+                        'id': provider_id,
+                        'sip_proxy_ip': proxy_ip,
+                        'sip_proxy_port': proxy_port,
+                        'dtmf_mode': line_dtmf_mode,
+                        'sip_transport': sip_transport,
+                    }
+                    line['provider_id'] = provider_id
+                    voip_providers[(proxy_ip, proxy_port)] = provider
+                    provider_id += 1
+                else:
+                    line['provider_id'] = voip_providers[(proxy_ip, proxy_port)]['id']
+
+        raw_config['XX_voip_providers'] = list(voip_providers.values())
+
+    def _add_ac_code(self, raw_config):
+        sip_lines = raw_config.get('sip_lines')
+        if sip_lines:
+            for line in sip_lines.values():
+                number = line.get('number')
+                if number.startswith('auto'):
+                    line['XX_hs_code'] = '0000'
+                else:
+                    line['XX_hs_code'] = number[-4:].zfill(4)
+
+    def configure(self, device, raw_config):
+        self._check_device(device)
+        filename = self._dev_specific_filename(device)
+        tpl = self._tpl_helper.get_dev_template(filename, device)
+
+        self._add_voip_providers(raw_config)
+        self._add_ac_code(raw_config)
+        self._add_xx_vars(device, raw_config)
+        self._add_phonebook(raw_config)
+
+        path = os.path.join(self._tftpboot_dir, filename)
+        self._tpl_helper.dump(tpl, raw_config, path, self._ENCODING)
+
+    def deconfigure(self, device):
+        path = os.path.join(self._tftpboot_dir, self._dev_specific_filename(device))
+        try:
+            os.remove(path)
+        except OSError as e:
+            logger.info('error while removing configuration file: %s', e)
+
+    def is_sensitive_filename(self, filename):
+        return bool(self._SENSITIVE_FILENAME_REGEX.match(filename))
+
+    def synchronize(self, device, raw_config):
+        return synchronize.standard_sip_synchronize(device)

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
@@ -87,11 +87,11 @@ class BaseGigasetPlugin(StandardPlugin):
     _ENCODING = 'UTF-8'
 
     _LOCALE = {
-        'de_DE': ('Germany'),
-        'en_US': ('Retail'),
-        'es_ES': ('Spain'),
-        'fr_FR': ('France'),
-        'fr_CA': ('Retail'),
+        'de_DE': 'Germany',
+        'en_US': 'Retail',
+        'es_ES': 'Spain',
+        'fr_FR': 'France',
+        'fr_CA': 'Retail',
     }
     _SIP_DTMF_MODE = {
         'RTP-in-band': '1',
@@ -241,9 +241,7 @@ class BaseGigasetPlugin(StandardPlugin):
     def _add_country_and_lang(self, raw_config):
         locale = raw_config.get('locale')
         if locale in self._LOCALE:
-            (
-                raw_config['XX_country'],
-            ) = self._LOCALE[locale]
+            raw_config['XX_country'] = self._LOCALE[locale]
         else:
             raw_config['XX_country'] = 'Retail'
 
@@ -304,6 +302,7 @@ class BaseGigasetPlugin(StandardPlugin):
         filename = self._dev_specific_filename(device)
         tpl = self._tpl_helper.get_dev_template(filename, device)
 
+        self._add_country_and_lang(raw_config)
         self._add_voip_providers(raw_config)
         self._add_ac_code(raw_config)
         self._add_xx_vars(device, raw_config)

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
@@ -32,7 +32,6 @@ VENDOR = 'Gigaset'
 
 
 class GigasetHTTPDeviceInfoExtractor:
-
     _UA_REGEX = re.compile(
         r'^"?(Gigaset )?(?P<model>[\w\s]+)\/(?P<version>(?:\w{2,3}\.){3,4}\w{1,3})(?:\+.+)?;'
         r'(?P<mac>[0-9A-F]{12})?(;Handset=\d+)?"?$'

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
@@ -86,6 +86,13 @@ class BaseGigasetPgAssociator(BasePgAssociator):
 class BaseGigasetPlugin(StandardPlugin):
     _ENCODING = 'UTF-8'
 
+    _LOCALE = {
+        'de_DE': ('Germany'),
+        'en_US': ('Retail'),
+        'es_ES': ('Spain'),
+        'fr_FR': ('France'),
+        'fr_CA': ('Retail'),
+    }
     _SIP_DTMF_MODE = {
         'RTP-in-band': '1',
         'RTP-out-of-band': '2',
@@ -230,6 +237,15 @@ class BaseGigasetPlugin(StandardPlugin):
     def _add_phonebook(self, raw_config):
         uuid_format = '{scheme}://{hostname}:{port}/0.1/directories/lookup/{profile}/gigaset/{user_uuid}?'  # noqa: E501
         plugins.add_xivo_phonebook_url_from_format(raw_config, uuid_format)
+
+    def _add_country_and_lang(self, raw_config):
+        locale = raw_config.get('locale')
+        if locale in self._LOCALE:
+            (
+                raw_config['XX_country'],
+            ) = self._LOCALE[locale]
+        else:
+            raw_config['XX_country'] = 'Retail'
 
     def _fix_timezone(self, raw_config):
         timezone = raw_config.get('timezone', 'Greenwich')

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/entry.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/entry.py
@@ -6,7 +6,8 @@ execfile_('common.py', common)
 
 
 MODEL_VERSIONS = {
-    'N870 IP PRO': '83.V2.48.0',
+    'N670 IP PRO': '83.V2.49.1',
+    'N870 IP PRO': '83.V2.49.1',
 }
 
 

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/entry.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/entry.py
@@ -8,6 +8,7 @@ execfile_('common.py', common)
 MODEL_VERSIONS = {
     'N670 IP PRO': '83.V2.49.1',
     'N870 IP PRO': '83.V2.49.1',
+    'N870E IP PRO': '83.V2.49.1',
 }
 
 

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/entry.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/entry.py
@@ -1,0 +1,16 @@
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+common = {}
+execfile_('common.py', common)
+
+
+MODEL_VERSIONS = {
+    'N870 IP PRO': '83.V2.48.0',
+}
+
+
+class GigasetPlugin(common['BaseGigasetPlugin']):
+    IS_PLUGIN = True
+
+    pg_associator = common['BaseGigasetPgAssociator'](MODEL_VERSIONS)

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/install.md
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/install.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-The `Gigaset N870 IP Pro` needs to be set to the correct role to work with Wazo. By default, the
+The `Gigaset Nx70 IP Pro` needs to be set to the correct role to work with Wazo. By default, the
 N870 is set only as a *base*, which means that it does not provide a web interface and needs an
 external DECT manager to be able to work properly. It is necessary to set it to the **All-in-one**
 role if you want to use it with Wazo. See the [Gigaset

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/install.md
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/install.md
@@ -1,0 +1,18 @@
+# Installation
+
+## Role
+
+The `Gigaset N870 IP Pro` needs to be set to the correct role to work with Wazo. By default, the
+N870 is set only as a *base*, which means that it does not provide a web interface and needs an
+external DECT manager to be able to work properly. It is necessary to set it to the **All-in-one**
+role if you want to use it with Wazo. See the [Gigaset
+documentation](https://teamwork.gigaset.com/gigawiki/display/GPPPO/FAQ+Nx70+-+Installation) to know
+how to change the role.
+
+## Handset authentication code
+
+In order for the handsets to associate with the DECT base station, it is necessary to enter a PIN in
+the register menu on the handset. The authentication code for a device in autoprov mode is `0000`.
+For all subsequent handsets, the code is the last four digits of the line extension (e.g. if you
+have the `421234` extension, the code will be `1234`). If the line extension is less than four
+digits long, leading zeros will be added (e.g. `1` will have the code `0001`).

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/limitations.md
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/limitations.md
@@ -1,0 +1,3 @@
+# Limitations
+
+The `Gigaset N870 IP Pro` does not support setting the extension to call for *call forwarding*, *do not disturb*, etc.

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/limitations.md
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/limitations.md
@@ -1,3 +1,3 @@
 # Limitations
 
-The `Gigaset N870 IP Pro` does not support setting the extension to call for *call forwarding*, *do not disturb*, etc.
+The `Gigaset Nx70 IP Pro` does not support setting the extension to call for *call forwarding*, *do not disturb*, etc.

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/pkgs/pkgs.db
@@ -1,15 +1,15 @@
-[pkg_N870-fw]
-description: Firmware for Gigaset N870 IP PRO
-description_fr: Micrologiciel pour Gigaset N870 IP PRO
-version: 83.V2.48.0
-files: N870-fw
-install: N870-fw
+[pkg_Nx70-fw]
+description: Firmware for Gigaset N670 IP PRO and N870 IP PRO
+description_fr: Micrologiciel pour Gigaset N670 IP PRO et N870 IP PRO
+version: 83.V2.49.1
+files: Nx70-fw
+install: Nx70-fw
 
-[install_N870-fw]
+[install_Nx70-fw]
 a-b: cp $FILE1 ./
 
-[file_N870-fw]
-filename: Gigaset-Nx70-V2.48.0-build.4fa8a54.bin
-url: https://profile.gigaset.net/device/83/1/firmware/Gigaset-Nx70-V2.48.0-build.4fa8a54.bin
-size: 47647104
-sha1sum: b10118e612b6b643cdecc75dc3a2b67edaaf4261
+[file_Nx70-fw]
+filename: Gigaset-Nx70-V2.49.1-build.0fc46d7.bin
+url: https://profile.gigaset.net/device/83/1/firmware/Gigaset-Nx70-V2.49.1-build.0fc46d7.bin
+size: 47667584
+sha1sum: 1e681036a56d7f563cc6485db23f307b21d0a458

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/pkgs/pkgs.db
@@ -1,0 +1,15 @@
+[pkg_N870-fw]
+description: Firmware for Gigaset N870 IP PRO
+description_fr: Micrologiciel pour Gigaset N870 IP PRO
+version: 83.V2.48.0
+files: N870-fw
+install: N870-fw
+
+[install_N870-fw]
+a-b: cp $FILE1 ./
+
+[file_N870-fw]
+filename: Gigaset-Nx70-V2.48.0-build.4fa8a54.bin
+url: https://profile.gigaset.net/device/83/1/firmware/Gigaset-Nx70-V2.48.0-build.4fa8a54.bin
+size: 47647104
+sha1sum: b10118e612b6b643cdecc75dc3a2b67edaaf4261

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/pkgs/pkgs.db
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/pkgs/pkgs.db
@@ -1,6 +1,6 @@
 [pkg_Nx70-fw]
-description: Firmware for Gigaset N670 IP PRO and N870 IP PRO
-description_fr: Micrologiciel pour Gigaset N670 IP PRO et N870 IP PRO
+description: Firmware for Gigaset N670 IP PRO and N870(E) IP PRO
+description_fr: Micrologiciel pour Gigaset N670 IP PRO et N870(E) IP PRO
 version: 83.V2.49.1
 files: Nx70-fw
 install: Nx70-fw

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/plugin-info
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/plugin-info
@@ -1,0 +1,14 @@
+{
+    "version": "0.1.1",
+    "description": "Plugin for Gigaset N870 IP PRO.",
+    "description_fr": "Greffon pour Gigaset N870 IP PRO.",
+    "capabilities": {
+        "Gigaset, N870 IP PRO, 83.V2.48.0": {
+            "lines": 250,
+            "ha": true,
+            "expansions": false,
+            "switchboard": false,
+            "proto": "sip"
+        }
+    }
+}

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/plugin-info
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/plugin-info
@@ -1,7 +1,7 @@
 {
     "version": "0.1.1",
-    "description": "Plugin for Gigaset N670 IP PRO and N870 IP PRO.",
-    "description_fr": "Greffon pour Gigaset N670 IP PRO et N870 IP PRO.",
+    "description": "Plugin for Gigaset N670 IP PRO and N870(E) IP PRO.",
+    "description_fr": "Greffon pour Gigaset N670 IP PRO et N870(E) IP PRO.",
     "capabilities": {
         "Gigaset, N670 IP PRO, 83.V2.49.1": {
             "lines": 20,
@@ -12,6 +12,14 @@
             "protocol": "sip"
         },
         "Gigaset, N870 IP PRO, 83.V2.49.1": {
+            "lines": 250,
+            "high_availability": true,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "protocol": "sip"
+        },
+        "Gigaset, N870E IP PRO, 83.V2.49.1": {
             "lines": 250,
             "high_availability": true,
             "expansion_modules": 0,

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/plugin-info
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/plugin-info
@@ -1,14 +1,23 @@
 {
     "version": "0.1.1",
-    "description": "Plugin for Gigaset N870 IP PRO.",
-    "description_fr": "Greffon pour Gigaset N870 IP PRO.",
+    "description": "Plugin for Gigaset N670 IP PRO and N870 IP PRO.",
+    "description_fr": "Greffon pour Gigaset N670 IP PRO et N870 IP PRO.",
     "capabilities": {
-        "Gigaset, N870 IP PRO, 83.V2.48.0": {
-            "lines": 250,
-            "ha": true,
-            "expansions": false,
+        "Gigaset, N670 IP PRO, 83.V2.49.1": {
+            "lines": 20,
+            "high_availability": true,
+            "expansion_modules": 0,
             "switchboard": false,
-            "proto": "sip"
+            "type": "dect",
+            "protocol": "sip"
+        },
+        "Gigaset, N870 IP PRO, 83.V2.49.1": {
+            "lines": 250,
+            "high_availability": true,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "protocol": "sip"
         }
     }
 }

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/templates/base.tpl
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/templates/base.tpl
@@ -2,7 +2,7 @@
 <provisioning version="1.1" productID="e2">
     <firmware>
     {%- if http_port %}
-        <file version="2.48.0" url="http://{{ ip }}:{{ http_port }}/Gigaset-Nx70-V2.48.0-build.4fa8a54.bin"/>
+        <file version="2.49.1" url="http://{{ ip }}:{{ http_port }}/Gigaset-Nx70-V2.49.1-build.0fc46d7.bin"/>
     {%- endif %}
     </firmware>
 
@@ -17,9 +17,10 @@
         <param name="Provisioning.global.ProvisioningServer" value="http://{{ ip }}:{{ http_port }}"/>
     {%- endif %}
 
-        <!-- N870 Telephony - Call settings -->
+        <!-- Nx70 Telephony - Call settings -->
         <param name="Telephony.0.CT_ViaRKey" value="1"/>
         <param name="Telephony.0.CT_ByOnHook" value="1"/>
+        <param name="Telephony.0.ToneScheme" value="{{ XX_country }}"/>
 
         <param name="DmGlobal.0.SuotaEnable" value="1"/>
         <param name="DmGlobal.0.HSIdleDisplay" value="1"/>
@@ -76,22 +77,17 @@
         <param name="SipProvider.{{ provider['id'] }}.RegServerPort" value="{{ sip_registrar_port|d(5060) }}"/>
     {%- endif %}
         <param name="SipProvider.{{ provider['id'] }}.RegServerRefreshTimer" value="180"/>
-        <!-- Disable SIP TLS support for now due to a bug when putting received calls on hold
-             These 3 enclosed parameters will then be enforced to plain SIP below, until bug fixed
         <param name="SipProvider.{{ provider['id'] }}.TransportProtocol" value="{{ provider['sip_transport'] }}"/>
+        <param name="SipProvider.{{ provider['id'] }}.UseSIPS" value="0"/>
     {%- if provider['sip_transport'] == '3' %}
-        <param name="SipProvider.{{ provider['id'] }}.UseSIPS" value="1"/>
         <param name="SipProvider.{{ provider['id'] }}.SRTP_Enabled" value="1"/>
     {%- else %}
-        <param name="SipProvider.{{ provider['id'] }}.UseSIPS" value="0"/>
         <param name="SipProvider.{{ provider['id'] }}.SRTP_Enabled" value="0"/>
     {%- endif %}
         -->
-        <param name="SipProvider.{{ provider['id'] }}.TransportProtocol" value="1"/>
-        <param name="SipProvider.{{ provider['id'] }}.UseSIPS" value="0"/>
-        <param name="SipProvider.{{ provider['id'] }}.SRTP_Enabled" value="0"/>
         <param name="SipProvider.{{ provider['id'] }}.AcceptNonSRTPCalls" value="0"/>
         <param name="SipProvider.{{ provider['id'] }}.DTMFTransmission" value="{{ provider['dtmf_mode'] }}"/>
+        <param name="SipProvider.{{ provider['id'] }}.WithDeregOnHsNotReachable" value="1"/>
 
         <!-- Redundancy -->
 

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/templates/base.tpl
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/templates/base.tpl
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<provisioning version="1.1" productID="e2">
+    <firmware>
+    {%- if http_port %}
+        <file version="2.48.0" url="http://{{ ip }}:{{ http_port }}/Gigaset-Nx70-V2.48.0-build.4fa8a54.bin"/>
+    {%- endif %}
+    </firmware>
+
+    <nvm>
+        <oper name="DeleteNotProvisionedHS"/>
+    {%- if admin_password %}
+        <param name="WebUIAccounts.1.Password" value="{{ admin_password }}"/>
+    {%- endif %}
+        <param name="Telephony.0.ToneScheme" value="International"/>
+
+    {%- if http_port %}
+        <param name="Provisioning.global.ProvisioningServer" value="http://{{ ip }}:{{ http_port }}"/>
+    {%- endif %}
+
+        <!-- N870 Telephony - Call settings -->
+        <param name="Telephony.0.CT_ViaRKey" value="1"/>
+        <param name="Telephony.0.CT_ByOnHook" value="1"/>
+
+        <param name="DmGlobal.0.SuotaEnable" value="1"/>
+        <param name="DmGlobal.0.HSIdleDisplay" value="1"/>
+        <param name="DmGlobal.0.SystemRegDomain" value="EUR"/>
+
+
+        <!-- Date and time -->
+    {%- if ntp_enabled %}
+        <param name="DmGlobal.0.NtpServer" value="{{ ntp_ip }}"/>
+    {%- endif %}
+
+    {%- if timezone %}
+        <param name="DmGlobal.0.TimeZone" value="{{ timezone }}"/>
+    {%- endif %}
+
+{%- if sip_lines %}
+    {%- for line_no, line in sip_lines.items() %}
+        {%- set handset_no = line_no.zfill(5) %}
+        <!-- Handset {{ line_no }} -->
+        <oper value="{{ handset_no }}" name="add_hs">
+            <param name="hs.RegStatus" value="ToReg"/>
+        </oper>
+
+        <param name="hs.{{ handset_no }}.DECT_AC" value="{{ line['XX_hs_code'] }}"/>
+        <param name="SipAccount.{{ handset_no }}.AuthName" value="{{ line['auth_username']|d(line['username']) }}"/>
+        <param name="SipAccount.{{ handset_no }}.AuthPassword" value="{{ line['auth_password']|d(line['password']) }}"/>
+        <param name="SipAccount.{{ handset_no }}.ProviderId" value="{{ line['provider_id'] }}"/>
+        <param name="SipAccount.{{ handset_no }}.UserName" value="{{ line['auth_username']|d(line['username']) }}"/>
+        <param name="SipAccount.{{ handset_no }}.DisplayName" value="{{ line['number'] }} {{ line['display_name'] }}"/>
+        {%- if line['voicemail'] %}
+        <param name="SipAccount.{{ handset_no }}.VoiceMailMailbox" value="{{ line['voicemail'] }}"/>
+        <param name="SipAccount.{{ handset_no }}.VoiceMailActive" value="1"/>
+        {%- endif %}
+        <param name="hs.{{ handset_no }}.DirectAccessDir" value="0"/>
+        <param name="hs.{{ handset_no }}.IntKeyDir" value="20"/>
+
+    {%- endfor %}
+{%- endif %}
+
+{%- for provider in XX_voip_providers %}
+        <!-- VoIP Provider {{ provider['id'] }} settings -->
+
+        <param name="SipProvider.{{ provider['id'] }}.Name" value="Wazo{{ provider['id'] }}"/>
+
+        <!-- General data of your service provider -->
+
+    {%- if provider['sip_proxy_ip'] %}
+        <param name="SipProvider.{{ provider['id'] }}.Domain" value="{{ provider['sip_proxy_ip'] }}"/>
+        <param name="SipProvider.{{ provider['id'] }}.ProxyServerAddress" value="{{ provider['sip_proxy_ip'] }}"/>
+        <param name="SipProvider.{{ provider['id'] }}.ProxyServerPort" value="{{ provider['sip_proxy_port']|d(5060) }}"/>
+    {%- endif %}
+    {%- if sip_registrar_ip %}
+        <param name="SipProvider.{{ provider['id'] }}.RegServerAddress" value="{{ sip_registrar_ip }}"/>
+        <param name="SipProvider.{{ provider['id'] }}.RegServerPort" value="{{ sip_registrar_port|d(5060) }}"/>
+    {%- endif %}
+        <param name="SipProvider.{{ provider['id'] }}.RegServerRefreshTimer" value="180"/>
+        <!-- Disable SIP TLS support for now due to a bug when putting received calls on hold
+             These 3 enclosed parameters will then be enforced to plain SIP below, until bug fixed
+        <param name="SipProvider.{{ provider['id'] }}.TransportProtocol" value="{{ provider['sip_transport'] }}"/>
+    {%- if provider['sip_transport'] == '3' %}
+        <param name="SipProvider.{{ provider['id'] }}.UseSIPS" value="1"/>
+        <param name="SipProvider.{{ provider['id'] }}.SRTP_Enabled" value="1"/>
+    {%- else %}
+        <param name="SipProvider.{{ provider['id'] }}.UseSIPS" value="0"/>
+        <param name="SipProvider.{{ provider['id'] }}.SRTP_Enabled" value="0"/>
+    {%- endif %}
+        -->
+        <param name="SipProvider.{{ provider['id'] }}.TransportProtocol" value="1"/>
+        <param name="SipProvider.{{ provider['id'] }}.UseSIPS" value="0"/>
+        <param name="SipProvider.{{ provider['id'] }}.SRTP_Enabled" value="0"/>
+        <param name="SipProvider.{{ provider['id'] }}.AcceptNonSRTPCalls" value="0"/>
+        <param name="SipProvider.{{ provider['id'] }}.DTMFTransmission" value="{{ provider['dtmf_mode'] }}"/>
+
+        <!-- Redundancy -->
+
+        <param name="SipProvider.{{ provider['id'] }}.DnsQuery" value="0"/>
+
+        <!-- Failover Server -->
+    {%- if sip_backup_proxy_ip %}
+        <param name="SipProvider.{{ provider['id'] }}.FailoverServerEnabled" value="1"/>
+        <param name="SipProvider.{{ provider['id'] }}.FailoverServerAddress" value="{{ sip_backup_proxy_ip }}"/>
+        <param name="SipProvider.{{ provider['id'] }}.FailoverServerPort" value="{{ sip_backup_proxy_port|d(5060) }}"/>
+    {%- else %}
+        <param name="SipProvider.{{ provider['id'] }}.FailoverServerEnabled" value="0"/>
+    {%- endif %}
+{%- endfor %}
+
+        <!-- Directory -->
+        <param name="Netdir.1.Activated" value="1"/>
+        <param name="XMLDir.1.ProviderName" value="Wazo"/>
+        <param name="XMLDir.1.ServerURL" value="{{ XX_xivo_phonebook_url }}"/>
+        <param name="XMLDir.1.WhitePagesDirName" value="Directory"/>
+        <param name="XMLDir.1.StartWithListWP" value="1"/>
+        <!-- Network data of your service provider -->
+
+    {%- if sip_outbound_proxy_ip %}
+        <param name="SipProvider.0.OutboundProxyMode" value="0"/>
+        <param name="SipProvider.0.OutboundProxyAddress" value="{{ sip_outbound_proxy_ip }}"/>
+        <param name="SipProvider.0.OutboundProxyPort" value="{{ sip_outbound_proxy_port|d(5060) }}"/>
+    {%- else %}
+        <param name="SipProvider.0.OutboundProxyMode" value="2"/>
+    {%- endif %}
+    {%- if sip_subscribe_mwi %}
+        <param name="SipProvider.0.MWISubscription" value="1"/>
+    {%- else %}
+        <param name="SipProvider.0.MWISubscription" value="0"/>
+    {%- endif %}
+
+        <oper name="update_dm" value="local">
+            <param name="RegStart" value="{{ XX_epoch }}"/>
+            <param name="RegDuration" value="900"/>
+            <param name="DMPpasswd" value="Gigaset"/>
+        </oper>
+    </nvm>
+
+</provisioning>

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/templates/base.tpl
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/templates/base.tpl
@@ -11,7 +11,7 @@
     {%- if admin_password %}
         <param name="WebUIAccounts.1.Password" value="{{ admin_password }}"/>
     {%- endif %}
-        <param name="Telephony.0.ToneScheme" value="International"/>
+        <param name="Telephony.0.ToneScheme" value="{{ XX_country }}"/>
 
     {%- if http_port %}
         <param name="Provisioning.global.ProvisioningServer" value="http://{{ ip }}:{{ http_port }}"/>
@@ -20,7 +20,6 @@
         <!-- Nx70 Telephony - Call settings -->
         <param name="Telephony.0.CT_ViaRKey" value="1"/>
         <param name="Telephony.0.CT_ByOnHook" value="1"/>
-        <param name="Telephony.0.ToneScheme" value="{{ XX_country }}"/>
 
         <param name="DmGlobal.0.SuotaEnable" value="1"/>
         <param name="DmGlobal.0.HSIdleDisplay" value="1"/>

--- a/plugins/wazo-gigaset/build.py
+++ b/plugins/wazo-gigaset/build.py
@@ -31,6 +31,11 @@ def build_N870_83_v2_48_0(path):
     check_call(['rsync', '-rlp', '--exclude', '.*', 'N870-83.v2.48.0/', path])
 
 
+@target('Nx70-83.v2.49.1', 'wazo-gigaset-Nx70-83.v2.49.1')
+def build_Nx70_83_v2_49_1(path):
+    check_call(['rsync', '-rlp', '--exclude', '.*', 'Nx70-83.v2.49.1/', path])
+
+
 @target('C470', 'wazo-gigaset-C470')
 def build_C470(path):
     check_call(['rsync', '-rlp', '--exclude', '.*', 'common-c/', path])


### PR DESCRIPTION
Hi,

Let's add support for the new Gigaset `N670 IP PRO` (and also for the Gigaset `N870E IP PRO`), which shares exactly the same configuration as the already existing `N870 IP PRO`.
Let's then create a `Nx70 IP PRO` plugin (which is how Gigaset names them).

First commit is then a 1:1 copy of `N870-83.v2.48.0` plugin.

Next commits are modifications, explained below.
It add support for `N670 IP PRO` and  `N870E IP PRO`.
It updates firmware to [last `83.v2.49.1` version](https://teamwork.gigaset.com/gigawiki/pages/viewpage.action?pageId=1350862266).
It enables SIP TLS (kept disabled in #147), which now properly works (`SipProvider.0.UseSIPS` must be set to `0`, after support from Gigaset team).
It properly sets `ToneScheme` according to configured locale.
It deregisters accounts for detached handsets (`WithDeregOnHsNotReachable`), which makes more sense than the contrary.
Finally, it renames the keys to the ones [defined in the README](https://github.com/wazo-platform/wazo-provd-plugins#plugin-information-files).

Thank you 👍

_Note that this is a rework of #159, after the move to Python3._