### PR TITLE
fix : Add new MAC Prefix 70:1f:53 (SPA8000)

### DIFF
--- a/dhcp/dhcp/dhcpd_update/linksys.conf
+++ b/dhcp/dhcp/dhcpd_update/linksys.conf
@@ -218,9 +218,9 @@ subclass "voip-mac-address-prefix" 1:54:7c:69 {
     }
 }
 
-subclass "voip-mac-address-prefix" 70:1f:53:a0 {
+subclass "voip-mac-address-prefix" 1:70:1f:53 {
     if not exists vendor-class-identifier {
         option tftp-server-name = config-option VOIP.tftp-server-name;
-        log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Linksys PREFIX 70:1f:53:a0"));
+        log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Linksys PREFIX 1:70:1f:53"));
     }
 }

--- a/dhcp/dhcp/dhcpd_update/linksys.conf
+++ b/dhcp/dhcp/dhcpd_update/linksys.conf
@@ -217,3 +217,10 @@ subclass "voip-mac-address-prefix" 1:54:7c:69 {
         log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Linksys PREFIX 1:54:7c:69"));
     }
 }
+
+subclass "voip-mac-address-prefix" 70:1f:53:a0 {
+    if not exists vendor-class-identifier {
+        option tftp-server-name = config-option VOIP.tftp-server-name;
+        log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Linksys PREFIX 70:1f:53:a0"));
+    }
+}


### PR DESCRIPTION
New Cisco SPA8000 can come with MAC address prefix 70:1f:53

Consider adding this block inside linksys.conf dhcp_update file

subclass "voip-mac-address-prefix" 70:1f:53:a0 {
    if not exists vendor-class-identifier {
        option tftp-server-name = config-option VOIP.tftp-server-name;
        log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Linksys PREFIX 70:1f:53:a0"));
    }
}