### PR TITLE
Gigaset N720, tune code tone

### DIFF
--- a/plugins/wazo_gigaset/N720/plugin-info
+++ b/plugins/wazo_gigaset/N720/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.18",
+    "version": "0.1.19",
     "description": "Plugin for Gigaset N720 IP/DM PRO.",
     "description_fr": "Greffon pour Gigaset N720 IP/DM PRO.",
     "capabilities": {

--- a/plugins/wazo_gigaset/N720/templates/base.tpl
+++ b/plugins/wazo_gigaset/N720/templates/base.tpl
@@ -44,9 +44,6 @@
         <SYMB_ITEM ID="BS_IP_Data.aucS_NETWORK_DEVICENAME[%]" class="symb_item" value='"N720-DM-PRO"'/>
         <SYMB_ITEM ID="BS_RAP.astRAPServices[1].ActivateService" class="symb_item" value="0"/>
         <SYMB_ITEM ID="BS_CUSTOM.WebUIPassword" class="symb_item" value='"{{ admin_password }}"'/>
-    {%- if http_port %}
-        <SYMB_ITEM ID="BS_IP_Data.aucS_DATA_SERVER[%]" class="symb_item" value='"{{ XX_server_url }}"'/>
-    {%- endif %}
         <SYMB_ITEM ID="BS_CUSTOM.bit.UseRandomRegistrationPIN" class="symb_item" value="0"/>
     	<SYMB_ITEM ID="BS_CUSTOM.aucKdsPin[%]" class="symb_item" value="0x00,0x00"/>
         <SYMB_ITEM ID="BS_IP_Data.ucB_USE_DHCP" class="symb_item" value="1"/>
@@ -74,6 +71,7 @@
         <SYMB_ITEM ID="BS_IP_Data.aucS_HTTP_PROXY_URL[%]" class="symb_item" value='""'/>
         <SYMB_ITEM ID="BS_IP_Data.uiI_HTTP_PROXY_PORT" class="symb_item" value="8080"/>
         <SYMB_ITEM ID="BS_IP_Data.ucI_HTTPLANGUAGE" class="symb_item" value="1"/>
+        <SYMB_ITEM ID="BS_AE_SwConfig.ucCountryCodeTone" class="symb_item" value="{{ XX_country }}"/>
 
     {%- if ntp_enabled %}
         <SYMB_ITEM ID="BS_IP_Data.aucS_TIME_NTP_SERVER[%]" class="symb_item" value='"{{ ntp_ip }}"'/>

--- a/plugins/wazo_gigaset/common/common.py
+++ b/plugins/wazo_gigaset/common/common.py
@@ -143,6 +143,14 @@ class HTTPServiceWrapper(HTTPNoListingFileService):
 class BaseGigasetPlugin(StandardPlugin):
     _ENCODING = 'UTF-8'
 
+    _COUNTRY_CODE = {
+        'de_DE': '0',
+        'en_US': '1',
+        'es_ES': '6',
+        'fr_FR': '7',
+        'fr_CA': '1',
+    }
+
     _TZ_GIGASET = {
         (-12, 0): 0x00,
         (-11, 0): 0x01,
@@ -207,6 +215,13 @@ class BaseGigasetPlugin(StandardPlugin):
         uuid_format = '{scheme}://{hostname}:{port}/0.1/directories/lookup/default/gigaset/{user_uuid}?'  # noqa: E501
         plugins.add_xivo_phonebook_url_from_format(raw_config, uuid_format)
 
+    def _add_country_code(self, raw_config):
+        locale = raw_config.get('locale')
+        if locale in self._COUNTRY_CODE:
+            raw_config['XX_country'] = self._COUNTRY_CODE[locale]
+        else:
+            raw_config['XX_country'] = '0'
+
     def _add_timezone_code(self, raw_config):
         timezone = raw_config.get('timezone', 'Etc/UTC')
         tz_db = tzinform.TextTimezoneInfoDB()
@@ -258,6 +273,7 @@ class BaseGigasetPlugin(StandardPlugin):
         filename = self._dev_specific_filename(device)
         tpl = self._tpl_helper.get_dev_template(filename, device)
 
+        self._add_country_code(raw_config)
         self._add_sip_info(raw_config)
         self._add_xx_vars(device, raw_config)
         self._add_phonebook(raw_config)


### PR DESCRIPTION
Hello,

Here's a quick fix for Gigaset N720 to tune code tone.

While here, let's remove the `BS_IP_Data.aucS_DATA_SERVER` parameter, which is not a N720 parameter but a N510 one.
Provisioning documentation : https://teamwork.gigaset.com/gigawiki/display/GPPPO/Provisioning+step+by+step

Thank you 👍 