### PR TITLE
Snom, update firmware to 10.1.141.13

### DIFF
--- a/plugins/wazo-snom/10.1.141.13/entry.py
+++ b/plugins/wazo-snom/10.1.141.13/entry.py
@@ -1,0 +1,30 @@
+# Copyright 2018-2022 The Wazo Authors (see AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+common_globals = {}
+execfile_('common.py', common_globals)
+
+MODELS = [
+    'D315',
+    'D335',
+    'D345',
+    'D385',
+    'D712',
+    'D713',
+    '715',
+    'D717',
+    '725',
+    'D735',
+    'D785',
+    'D862',
+    'D865',
+]
+VERSION = '10.1.141.13'
+
+
+class SnomPlugin(common_globals['BaseSnomPlugin']):
+    IS_PLUGIN = True
+
+    _MODELS = MODELS
+
+    pg_associator = common_globals['BaseSnomPgAssociator'](MODELS, VERSION)

--- a/plugins/wazo-snom/10.1.141.13/pkgs/pkgs.db
+++ b/plugins/wazo-snom/10.1.141.13/pkgs/pkgs.db
@@ -1,0 +1,182 @@
+[pkg_315-fw]
+description: Firmware for Snom D315
+description_fr: Firmware pour Snom D315
+version: 10.1.141.13
+files: 315-fw
+install: snom-fw
+
+[pkg_335-fw]
+description: Firmware for Snom D335
+description_fr: Firmware pour Snom D335
+version: 10.1.141.13
+files: 335-fw
+install: snom-fw
+
+[pkg_345-fw]
+description: Firmware for Snom D345
+description_fr: Firmware pour Snom D345
+version: 10.1.141.13
+files: 345-fw
+install: snom-fw
+
+[pkg_385-fw]
+description: Firmware for Snom D385
+description_fr: Firmware pour Snom D385
+version: 10.1.141.13
+files: 385-fw
+install: snom-fw
+
+[pkg_712-fw]
+description: Firmware for Snom D712
+description_fr: Firmware pour Snom D712
+version: 10.1.141.13
+files: 712-fw
+install: snom-fw
+
+[pkg_713-fw]
+description: Firmware for Snom D713
+description_fr: Firmware pour Snom D713
+version: 10.1.141.13
+files: 713-fw
+install: snom-fw
+
+[pkg_715-fw]
+description: Firmware for Snom D715
+description_fr: Firmware pour Snom D715
+version: 10.1.141.13
+files: 715-fw
+install: snom-fw
+
+[pkg_717-fw]
+description: Firmware for Snom D717
+description_fr: Firmware pour Snom D717
+version: 10.1.141.13
+files: 717-fw
+install: snom-fw
+
+[pkg_725-fw]
+description: Firmware for Snom D725
+description_fr: Firmware pour Snom D725
+version: 10.1.141.13
+files: 725-fw
+install: snom-fw
+
+[pkg_735-fw]
+description: Firmware for Snom D735
+description_fr: Firmware pour Snom D735
+version: 10.1.141.13
+files: 735-fw
+install: snom-fw
+
+[pkg_785-fw]
+description: Firmware for Snom D785
+description_fr: Firmware pour Snom D785
+version: 10.1.141.13
+files: 785-fw
+install: snom-fw
+
+[pkg_862-fw]
+description: Firmware for Snom D862
+description_fr: Firmware pour Snom D862
+version: 10.1.141.13
+files: 862-fw
+install: snom-fw
+
+[pkg_865-fw]
+description: Firmware for Snom D865
+description_fr: Firmware pour Snom D865
+version: 10.1.141.13
+files: 865-fw
+install: snom-fw
+
+[pkg_uxm-fw]
+description: Firmware for Snom Extension USB Module UXM D3/D7
+description_fr: Micrologiciel pour module d'extension USB Snom UXM D3/D7
+version: 2.1.1
+files: uxm-fw
+install: snom-fw
+
+[pkg_uxmc-fw]
+description: Firmware for Snom Extension USB Module UXMC D7C
+description_fr: Micrologiciel pour module d'extension USB Snom UXMC D7C
+version: 1.1.1
+files: uxmc-fw
+install: snom-fw
+
+[install_snom-fw]
+a-b: cp $FILE1 firmware/
+
+[file_uxmc-fw]
+url: https://downloads.snom.com/fw/d7c/snomD7C-1.1.1-r.bin
+size: 35708675
+sha1sum:8722d0c3d6ce1374561302f703559faade15a49a
+
+[file_uxm-fw]
+url: https://downloads.snom.com/snomUXM-2.1.1.bin
+size: 96560
+sha1sum:9c4e07185ca6eb863858edf23147ab8576f94c4a
+
+[file_315-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD315-10.1.141.13-SIP-r.bin
+size: 31246640
+sha1sum: 7ccf4b66afc809e58197707155cd7758e1473cd5
+
+[file_335-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD335-10.1.141.13-SIP-r.bin
+size: 37964016
+sha1sum: ef50dcc8237ed3e53ccf5eda7cfab381519a7ee3
+
+[file_345-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD345-10.1.141.13-SIP-r.bin
+size: 31340256
+sha1sum: 9b17a4e7d69f2b1c627abc0d09d4647183909169
+
+[file_385-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD385-10.1.141.13-SIP-r.bin
+size: 38312688
+sha1sum: ae0d67a334c5035d3582b7f6b592eaf9844436e2
+
+[file_712-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD712-10.1.141.13-SIP-r.bin
+size: 25541696
+sha1sum: 1c99d66e3ffe949749e1b0d4b37e7a973adfd4d0
+
+[file_713-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD713-10.1.141.13-SIP-r.bin
+size: 39911296
+sha1sum: be3876734abbedf0adfaf002c79673c22ecbe2be
+
+[file_715-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snom715-10.1.141.13-SIP-r.bin
+size: 29102864
+sha1sum: e86f1914353fd87b0463e28db78656dc1f0cf381
+
+[file_717-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD717-10.1.141.13-SIP-r.bin
+size: 38861760
+sha1sum: aab694556b148545b62139bfda3b563eb88fa496
+
+[file_725-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snom725-10.1.141.13-SIP-r.bin
+size: 29107056
+sha1sum: 8d9b11576331c434d7a4e4323f58a3fefb0ce996
+
+[file_735-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD735-10.1.141.13-SIP-r.bin
+size: 38552864
+sha1sum: 5c4c4b15bef0e282d38a98419b8933ebb68fbfa0
+
+[file_785-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD785-10.1.141.13-SIP-r.bin
+size: 38793024
+sha1sum: cf6fc1afa49b815664b2c16b4d9c07efa87f1717
+
+[file_862-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD862-10.1.141.13-SIP-r.swu
+size: 126085120
+sha1sum: 8e22c39d3157bf78a3b91c906eeb8e2946187f88
+
+[file_865-fw]
+url: https://downloads.snom.com/fw/10.1.141.13/bin/snomD865-10.1.141.13-SIP-r.swu
+size: 126466048
+sha1sum: f262db0b1e283f055ac26758247ef5a4f17fe1fe

--- a/plugins/wazo-snom/10.1.141.13/plugin-info
+++ b/plugins/wazo-snom/10.1.141.13/plugin-info
@@ -1,7 +1,7 @@
 {
     "version": "0.7.2",
     "description": "Plugin for Snom D3x5, D71x, D7x5, D86x in version 10.1.141.13",
-    "description_fr": "Greffon pour Snom D3x5, D71x, D7x5 en version 10.1.141.13",
+    "description_fr": "Greffon pour Snom D3x5, D71x, D7x5, D86x en version 10.1.141.13",
     "capabilities": {
         "Snom, D315, 10.1.141.13": {
             "lines": 4,

--- a/plugins/wazo-snom/10.1.141.13/plugin-info
+++ b/plugins/wazo-snom/10.1.141.13/plugin-info
@@ -1,0 +1,124 @@
+{
+    "version": "0.7.2",
+    "description": "Plugin for Snom D3x5, D71x, D7x5, D86x in version 10.1.141.13",
+    "description_fr": "Greffon pour Snom D3x5, D71x, D7x5 en version 10.1.141.13",
+    "capabilities": {
+        "Snom, D315, 10.1.141.13": {
+            "lines": 4,
+            "high_availability": false,
+            "function_keys": 5,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D335, 10.1.141.13": {
+            "lines": 12,
+            "high_availability": false,
+            "function_keys": 32,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D345, 10.1.141.13": {
+            "lines": 12,
+            "high_availability": false,
+            "function_keys": 48,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D385, 10.1.141.13": {
+            "lines": 12,
+            "high_availability": false,
+            "function_keys": 48,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D712, 10.1.141.13": {
+            "lines": 4,
+            "high_availability": false,
+            "function_keys": 5,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D713, 10.1.141.13": {
+            "lines": 6,
+            "high_availability": false,
+            "function_keys": 4,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, 715, 10.1.141.13": {
+            "lines": 4,
+            "high_availability": false,
+            "function_keys": 5,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D717, 10.1.141.13": {
+            "lines": 6,
+            "high_availability": false,
+            "function_keys": 3,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, 725, 10.1.141.13": {
+            "lines": 12,
+            "high_availability": false,
+            "function_keys": 18,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D735, 10.1.141.13": {
+            "lines": 12,
+            "high_availability": false,
+            "function_keys": 32,
+            "expansion_modules": 3,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D785, 10.1.141.13": {
+            "lines": 12,
+            "high_availability": false,
+            "function_keys": 24,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D862, 10.1.141.13": {
+            "lines": 8,
+            "high_availability": false,
+            "function_keys": 8,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Snom, D865, 10.1.141.13": {
+            "lines": 12,
+            "high_availability": false,
+            "function_keys": 10,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        }
+    }
+}

--- a/plugins/wazo-snom/build.py
+++ b/plugins/wazo-snom/build.py
@@ -983,6 +983,8 @@ def build_10_1_141_13(path):
             path, 'templates', 'common', f'snom{model}-firmware.xml.tpl'
         )
         sed_script = f's/#FW_FILENAME#/snom{model}-10.1.141.13-SIP-{fw_suffix}.bin/'
+        if model.startswith("D8"):
+            sed_script = f's/#FW_FILENAME#/snom{model}-10.1.141.13-SIP-{fw_suffix}.swu/'
         with open(model_tpl, 'wb') as f:
             check_call(
                 [

--- a/plugins/wazo-snom/build.py
+++ b/plugins/wazo-snom/build.py
@@ -931,3 +931,84 @@ def build_10_1_101_11(path):
             )
 
     check_call(['rsync', '-rlp', '--exclude', '.*', '10.1.101.11/', path])
+
+
+@target('10.1.141.13', 'wazo-snom-10.1.141.13')
+def build_10_1_141_13(path):
+    MODELS = [
+        ('D315', 'r'),
+        ('D335', 'r'),
+        ('D345', 'r'),
+        ('D385', 'r'),
+        ('D712', 'r'),
+        ('D713', 'r'),
+        ('715', 'r'),
+        ('D717', 'r'),
+        ('725', 'r'),
+        ('D735', 'r'),
+        ('D785', 'r'),
+        ('D862', 'r'),
+        ('D865', 'r'),
+    ]
+    check_call(
+        [
+            'rsync',
+            '-rlp',
+            '--exclude',
+            '.*',
+            '--include',
+            '/templates/base.tpl',
+            '--include',
+            '/templates/D3*5.tpl',
+            '--include',
+            '/templates/D71*.tpl',
+            '--include',
+            '/templates/7*5.tpl',
+            '--include',
+            '/templates/D7*5.tpl',
+            '--include',
+            '/templates/D86*.tpl',
+            '--exclude',
+            '/templates/*.tpl',
+            '--exclude',
+            '*.btpl',
+            'common/',
+            path,
+        ]
+    )
+
+    for model, fw_suffix in MODELS:
+        # generate snom<model>-firmware.xml.tpl from snom-model-firmware.xml.tpl.btpl
+        model_tpl = os.path.join(
+            path, 'templates', 'common', f'snom{model}-firmware.xml.tpl'
+        )
+        sed_script = f's/#FW_FILENAME#/snom{model}-10.1.141.13-SIP-{fw_suffix}.bin/'
+        with open(model_tpl, 'wb') as f:
+            check_call(
+                [
+                    'sed',
+                    sed_script,
+                    'common/templates/common/snom-model-firmware.xml.tpl.btpl',
+                ],
+                stdout=f,
+            )
+
+        # generate snom<model>.htm.tpl from snom-model.htm.tpl.mtpl
+        model_tpl = os.path.join(path, 'templates', 'common', f'snom{model}.htm.tpl')
+        sed_script = f's/#MODEL#/{model}/'
+        with open(model_tpl, 'wb') as f:
+            check_call(
+                ['sed', sed_script, 'common/templates/common/snom-model.htm.tpl.btpl'],
+                stdout=f,
+            )
+
+        # generate snom<model>.xml.tpl from snom-model.xml.mtpl
+        model_tpl = os.path.join(path, 'templates', 'common', f'snom{model}.xml.tpl')
+        sed_script = f's/#MODEL#/{model}/'
+        with open(model_tpl, 'wb') as f:
+            check_call(
+                ['sed', sed_script, 'common/templates/common/snom-model.xml.tpl.btpl'],
+                stdout=f,
+            )
+
+    check_call(['rsync', '-rlp', '--exclude', '.*', '10.1.141.13/', path])


### PR DESCRIPTION
Hello,

This plugin updates Snom firmware to 10.1.141.13.
https://service.snom.com/display/wiki/10.1.141.13+Release

While here, it also adds new devices to the list : [D713](https://service.snom.com/display/wiki/D713), [D862](https://service.snom.com/display/wiki/D862) and [D865](https://service.snom.com/display/wiki/D865).

Thx 👍 