### PR TITLE
polycom: add MAC address to User Agent

### DIFF
--- a/plugins/wazo_polycom/common/templates/base.tpl
+++ b/plugins/wazo_polycom/common/templates/base.tpl
@@ -2,6 +2,7 @@
 <polycomConfig
 
 device.set="1"
+device.prov.tagSerialNo="1"
 
 {# VLAN settings -#}
 device.net.vlanId.set="1"

--- a/plugins/wazo_polycom/common/templates/base.tpl
+++ b/plugins/wazo_polycom/common/templates/base.tpl
@@ -2,6 +2,7 @@
 <polycomConfig
 
 device.set="1"
+device.prov.tagSerialNo.set="1"
 device.prov.tagSerialNo="1"
 
 {# VLAN settings -#}

--- a/plugins/wazo_polycom/v5_4_3/var/tftpboot/common.cfg
+++ b/plugins/wazo_polycom/v5_4_3/var/tftpboot/common.cfg
@@ -3,6 +3,9 @@
 
 apps.push.secureTunnelRequired="0"
 
+device.prov.tagSerialNo.set="1"
+device.prov.tagSerialNo="1"
+
 attendant.behaviors.display.spontaneousCallAppearances.normal="0"
 
 dialplan.digitmap="[0123456789*#].T"

--- a/plugins/wazo_polycom/v5_9_2/plugin-info
+++ b/plugins/wazo_polycom/v5_9_2/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Plugin for Polycom VVX101, VVX150, VVX201, VVX250, VVX300, VVX301, VVX310, VVX311, VVX350, VVX400, VVX401, VVX410, VVX411, VVX450, VVX500, VVX501, VVX600, VVX601 and VVX1500 in version 5.9.2",
     "description_fr": "Greffon pour Polycom VVX101, VVX150, VVX201, VVX250, VVX300, VVX301, VVX310, VVX311, VVX350, VVX400, VVX401, VVX410, VVX411, VVX450, VVX500, VVX501, VVX600, VVX601 and VVX1500 en version 5.9.2",
     "capabilities": {


### PR DESCRIPTION
Why: needed when doing requests through NAT