### PR TITLE
Run pyupgrade (py37) to update to a more modern syntax

### DIFF
--- a/plugins/wazo-aastra/common/common.py
+++ b/plugins/wazo-aastra/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@ import logging
 import re
 import os.path
 from operator import itemgetter
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -90,7 +89,7 @@ class BaseAastraPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Aastra':
             if model in self._model_versions:
@@ -475,7 +474,7 @@ class BaseAastraPlugin(StandardPlugin):
     def _add_xivo_phonebook_url(self, raw_config):
         plugins.add_xivo_phonebook_url(raw_config, 'aastra')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=True)
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-alcatel/1.51.52/common.py
+++ b/plugins/wazo-alcatel/1.51.52/common.py
@@ -1,11 +1,10 @@
-# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import os.path
 import re
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -66,7 +65,7 @@ class BaseAlcatelMyriadPgAssociator(BasePgAssociator):
         self._models_versions = models_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Alcatel-Lucent':
             if model in self._models_versions:
@@ -247,7 +246,7 @@ class BaseAlcatelPlugin(StandardPlugin):
         if 'model' not in device:
             raise Exception('Model name needed for device configuration')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         return f'config.{format_mac(device["mac"], separator="")}.xml'
 
     def _add_server_url(self, raw_config):

--- a/plugins/wazo-alcatel/2.01.10/common.py
+++ b/plugins/wazo-alcatel/2.01.10/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@ import logging
 import os.path
 import re
 import time
-from typing import Dict, Optional
 
 from provd import tzinform
 from provd.devices.config import RawConfigError
@@ -79,7 +78,7 @@ class BaseAlcatelHTTPDeviceInfoExtractor:
             }
         return None
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         # try to extract MAC address from path
         m = self._PATH_REGEX.search(path)
         if m:
@@ -113,7 +112,7 @@ class BaseAlcatelPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == VENDOR:
             if model in self._models:
@@ -296,7 +295,7 @@ class BaseAlcatelPlugin(StandardPlugin):
     def _update_admin_password(self, raw_config):
         raw_config.setdefault('admin_password', self._DEFAULT_PASSWORD)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
         return f'sipconfig-{formatted_mac}.txt'

--- a/plugins/wazo-alcatel/2.13.02/common.py
+++ b/plugins/wazo-alcatel/2.13.02/common.py
@@ -1,11 +1,10 @@
-# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import os.path
 import re
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -66,7 +65,7 @@ class BaseAlcatelMyriadPgAssociator(BasePgAssociator):
         self._models_versions = models_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Alcatel-Lucent':
             if model in self._models_versions:
@@ -209,7 +208,7 @@ class BaseAlcatelPlugin(StandardPlugin):
         tz_hms = tzinfo['utcoffset'].as_hms
         offset_hour = tz_hms[0]
         offset_minutes = tz_hms[1]
-        return '{:+02d}:{:02d}'.format(offset_hour, offset_minutes)
+        return f'{offset_hour:+02d}:{offset_minutes:02d}'
 
     def _add_timezone(self, raw_config):
         if 'timezone' in raw_config:
@@ -249,7 +248,7 @@ class BaseAlcatelPlugin(StandardPlugin):
         if 'model' not in device:
             raise Exception('Model name needed for device configuration')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         return f'config.{format_mac(device["mac"], separator="")}.xml'
 
     def _add_server_url(self, raw_config):

--- a/plugins/wazo-avaya/common/common.py
+++ b/plugins/wazo-avaya/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +23,6 @@ from __future__ import annotations
 import re
 import os
 import logging
-from typing import Dict, Optional
 
 from provd import tzinform
 from provd import synchronize
@@ -76,7 +75,7 @@ class BaseAvayaHTTPDeviceInfoExtractor:
             return {'vendor': 'Avaya', 'version': m.group(1)}
         return None
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         m = self._PATH_REGEX.search(path)
         if m:
             dev_info['mac'] = norm_mac(m.group(1))
@@ -107,7 +106,7 @@ class BaseAvayaPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Avaya':
             if model in self._models:
@@ -152,7 +151,7 @@ class BaseAvayaPlugin(StandardPlugin):
                     'XX_timezone'
                 ] = f'TIMEZONE_OFFSET {tzinfo["utcoffset"].as_seconds:d}'
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=True)
         return f'SIP{formatted_mac}.cfg'

--- a/plugins/wazo-cisco-sccp/common/common.py
+++ b/plugins/wazo-cisco-sccp/common/common.py
@@ -1,11 +1,10 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 from __future__ import annotations
 
 import logging
 import os
 import re
-from typing import Dict, Optional, Union
 
 from provd import plugins
 from provd import tzinform
@@ -29,8 +28,8 @@ class BaseCiscoPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
-    ) -> Union[DeviceSupport, int]:
+        self, vendor: str, model: str | None, version: str | None
+    ) -> DeviceSupport | int:
         if vendor == 'Cisco':
             if model is None:
                 # when model is None, give a score slightly higher than
@@ -287,7 +286,7 @@ class BaseCiscoSccpPlugin(StandardPlugin):
         for priority, call_manager in raw_config['sccp_call_managers'].items():
             call_manager['XX_priority'] = str(int(priority) - 1)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=True)
         return f'SEP{formatted_mac}.cnf.xml'

--- a/plugins/wazo-cisco-sip/11.1.0/common.py
+++ b/plugins/wazo-cisco-sip/11.1.0/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 from __future__ import annotations
 
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 from operator import itemgetter
-from typing import Dict, Optional
 from xml.sax.saxutils import escape
 from provd import plugins
 from provd import tzinform
@@ -80,7 +79,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
                 return dev_info
         return None
 
-    def _extract_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_from_ua(self, ua: str, dev_info: dict[str, str]):
         # HTTP User-Agent:
         # Note: the last group of digit is the serial number
         #   It is not possible to extract the MAC address from the UA on these ATAs
@@ -93,7 +92,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
             if dev_sn:
                 dev_info['sn'] = dev_sn
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         # try to extract MAC address from path
         m = self._PATH_REGEX.search(path)
         if m:
@@ -139,7 +138,7 @@ class BaseCiscoPgAssociator(BasePgAssociator):
         self._model_version = model_version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Cisco':
             if model in self._model_version:

--- a/plugins/wazo-cisco-sip/11.3.1/common.py
+++ b/plugins/wazo-cisco-sip/11.3.1/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 from __future__ import annotations
 
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 from operator import itemgetter
-from typing import Dict, Optional
 from xml.sax.saxutils import escape
 from provd import plugins
 from provd import tzinform
@@ -71,7 +70,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
                 return dev_info
         return None
 
-    def _extract_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_from_ua(self, ua: str, dev_info: dict[str, str]):
         # HTTP User-Agent:
         # Note: the last group of digit is the serial number;
         #       the first, if present, is the MAC address
@@ -84,7 +83,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
             if raw_mac:
                 dev_info['mac'] = norm_mac(raw_mac)
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         # try to extract MAC address from path
         m = self._PATH_REGEX.search(path)
         if m:
@@ -135,7 +134,7 @@ class BaseCiscoPgAssociator(BasePgAssociator):
         self._model_version = model_version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Cisco':
             if model in self._model_version:
@@ -355,7 +354,7 @@ class BaseCiscoSipPlugin(StandardPlugin):
     def _add_xivo_phonebook_url(self, raw_config):
         plugins.add_xivo_phonebook_url(raw_config, 'cisco')
 
-    def _dev_specific_filename(self, dev: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, dev: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(dev['mac'], separator='')
         return f'{formatted_mac}.xml'

--- a/plugins/wazo-cisco-sip/12.0.1/common.py
+++ b/plugins/wazo-cisco-sip/12.0.1/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 from __future__ import annotations
 
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 from operator import itemgetter
-from typing import Dict, Optional
 from xml.sax.saxutils import escape
 from provd import plugins
 from provd import tzinform
@@ -71,7 +70,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
                 return dev_info
         return None
 
-    def _extract_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_from_ua(self, ua: str, dev_info: dict[str, str]):
         # HTTP User-Agent:
         # Note: the last group of digit is the serial number;
         #       the first, if present, is the MAC address
@@ -84,7 +83,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
             if raw_mac:
                 dev_info['mac'] = norm_mac(raw_mac)
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         # try to extract MAC address from path
         m = self._PATH_REGEX.search(path)
         if m:
@@ -135,7 +134,7 @@ class BaseCiscoPgAssociator(BasePgAssociator):
         self._model_version = model_version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Cisco':
             if model in self._model_version:
@@ -350,7 +349,7 @@ class BaseCiscoSipPlugin(StandardPlugin):
     def _add_xivo_phonebook_url(self, raw_config):
         plugins.add_xivo_phonebook_url(raw_config, 'cisco')
 
-    def _dev_specific_filename(self, dev: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, dev: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(dev['mac'], separator='')
         return f'{formatted_mac}.xml'

--- a/plugins/wazo-cisco-sip/common/common.py
+++ b/plugins/wazo-cisco-sip/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 import os
 import re
-from typing import Optional, Union
 
 from provd import plugins
 from provd import tzinform
@@ -42,8 +41,8 @@ class BaseCiscoPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
-    ) -> Union[DeviceSupport, int]:
+        self, vendor: str, model: str | None, version: str | None
+    ) -> DeviceSupport | int:
         if vendor == 'Cisco':
             if model is None:
                 # when model is None, give a score slightly higher than

--- a/plugins/wazo-cisco-spa/7.5.5/entry.py
+++ b/plugins/wazo-cisco-spa/7.5.5/entry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ PSN = [
     '525G2',
 ]
 MODELS = ['SPA' + psn for psn in PSN]
-MODEL_VERSION = dict((model, '7.5.5') for model in MODELS)
+MODEL_VERSION = {model: '7.5.5' for model in MODELS}
 
 
 class CiscoPlugin(common_globals['BaseCiscoPlugin']):

--- a/plugins/wazo-cisco-spa/common/common.py
+++ b/plugins/wazo-cisco-spa/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ import os
 import re
 from copy import deepcopy
 from operator import itemgetter
-from typing import Dict, Optional
 from xml.sax.saxutils import escape
 from provd import plugins
 from provd import tzinform
@@ -93,7 +92,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
                 return dev_info
         return None
 
-    def _extract_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_from_ua(self, ua: str, dev_info: dict[str, str]):
         # HTTP User-Agent:
         # Note: the last group of digit is the serial number;
         #       the first, if present, is the MAC address
@@ -109,7 +108,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
         elif ua.startswith('Cisco/'):
             self._extract_cisco_from_ua(ua, dev_info)
 
-    def _extract_linksys_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_linksys_from_ua(self, ua: str, dev_info: dict[str, str]):
         # Pre: ua.startswith('Linksys/')
         m = self._LINKSYS_UA_REGEX.match(ua)
         if m:
@@ -118,7 +117,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
             dev_info['version'] = version
             dev_info['sn'] = sn
 
-    def _extract_cisco_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_cisco_from_ua(self, ua: str, dev_info: dict[str, str]):
         # Pre: ua.startswith('Cisco/')
         m = self._CISCO_UA_REGEX.match(ua)
         if m:
@@ -129,7 +128,7 @@ class BaseCiscoHTTPDeviceInfoExtractor:
                 dev_info['mac'] = norm_mac(raw_mac)
             dev_info['sn'] = sn
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         # try to extract MAC address from path
         m = self._PATH_REGEX.search(path)
         if m:
@@ -193,7 +192,7 @@ class BaseCiscoPgAssociator(BasePgAssociator):
         self._model_version = model_version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Cisco':
             if model in self._model_version:
@@ -414,7 +413,7 @@ class BaseCiscoPlugin(StandardPlugin):
     def _add_xivo_phonebook_url(self, raw_config):
         plugins.add_xivo_phonebook_url(raw_config, 'cisco')
 
-    def _dev_specific_filename(self, dev: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, dev: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(dev['mac'], separator='')
 

--- a/plugins/wazo-digium/common/common.py
+++ b/plugins/wazo-digium/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 import os
 import re
-from typing import Dict, Optional
 
 from provd import synchronize
 from provd.util import norm_mac, format_mac
@@ -81,7 +80,7 @@ class DigiumPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Digium':
             if model in self._MODELS:
@@ -170,7 +169,7 @@ class BaseDigiumPlugin(StandardPlugin):
     def _format_mac(self, device):
         return format_mac(device['mac'], separator='', uppercase=False)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         return f'{self._format_mac(device)}.cfg'
 
     def _dev_contact_filename(self, device):

--- a/plugins/wazo-fanvil/common/common.py
+++ b/plugins/wazo-fanvil/common/common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os.path
 import re
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import synchronize
@@ -77,7 +76,7 @@ class BaseFanvilPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Fanvil':
             if model in self._models:
@@ -150,7 +149,7 @@ class BaseFanvilPlugin(StandardPlugin):
         self.services = fetchfw_helper.services()
         self.http_service = HTTPNoListingFileService(self._base_tftpboot_dir)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-gigaset/N870-83.v2.39.0/common.py
+++ b/plugins/wazo-gigaset/N870-83.v2.39.0/common.py
@@ -1,5 +1,5 @@
 """
-Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 SPDX-License-Identifier: GPL-3.0-or-later
 
 Common code shared by the various wazo-gigaset plugins.
@@ -10,7 +10,6 @@ import os
 import logging
 import re
 import time
-from typing import Dict, Optional
 
 from provd import (
     plugins,
@@ -70,7 +69,7 @@ class BaseGigasetPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == VENDOR:
             if model in self._models:
@@ -226,7 +225,7 @@ class BaseGigasetPlugin(StandardPlugin):
         if 'ip' not in device:
             raise Exception('IP address needed for Gigaset configuration')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
         return f'{formatted_mac}.xml'

--- a/plugins/wazo-gigaset/N870-83.v2.48.0/common.py
+++ b/plugins/wazo-gigaset/N870-83.v2.48.0/common.py
@@ -1,5 +1,5 @@
 """
-Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 SPDX-License-Identifier: GPL-3.0-or-later
 
 Common code shared by the various wazo-gigaset plugins.
@@ -10,7 +10,6 @@ import os
 import logging
 import re
 import time
-from typing import Dict, Optional
 
 from provd import (
     plugins,
@@ -71,7 +70,7 @@ class BaseGigasetPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == VENDOR:
             if model in self._models:
@@ -221,7 +220,7 @@ class BaseGigasetPlugin(StandardPlugin):
         if 'ip' not in device:
             raise Exception('IP address needed for Gigaset configuration')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
         return f'{formatted_mac}.xml'

--- a/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
+++ b/plugins/wazo-gigaset/Nx70-83.v2.49.1/common.py
@@ -1,5 +1,5 @@
 """
-Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 SPDX-License-Identifier: GPL-3.0-or-later
 
 Common code shared by the various wazo-gigaset plugins.
@@ -10,7 +10,6 @@ import os
 import logging
 import re
 import time
-from typing import Dict, Optional
 
 from provd import (
     plugins,
@@ -71,7 +70,7 @@ class BaseGigasetPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == VENDOR:
             if model in self._models:
@@ -228,7 +227,7 @@ class BaseGigasetPlugin(StandardPlugin):
         if 'ip' not in device:
             raise Exception('IP address needed for Gigaset configuration')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
         return f'{formatted_mac}.xml'

--- a/plugins/wazo-gigaset/common-c/common.py
+++ b/plugins/wazo-gigaset/common-c/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@ import urllib.request
 from configparser import RawConfigParser
 from contextlib import closing
 from io import StringIO
-from typing import Optional
 
 from provd.devices.pgasso import BasePgAssociator, DeviceSupport
 from provd.plugins import StandardPlugin, TemplatePluginHelper
@@ -76,7 +75,7 @@ class BaseGigasetPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == VENDOR:
             if model in self._models:
@@ -331,9 +330,9 @@ class BaseGigasetPlugin(StandardPlugin):
                         mailboxes[line_no] = voicemail
 
             # do generic requests stuff here
-            config_dict = dict(
-                (s, dict(config.items(s))) for s in config.sections() if s != 'general'
-            )
+            config_dict = {
+                s: dict(config.items(s)) for s in config.sections() if s != 'general'
+            }
             for path, raw_data in config_dict.items():
                 with broker.do_post_request(path, raw_data) as fobj:
                     fobj.read()

--- a/plugins/wazo-gigaset/common/common.py
+++ b/plugins/wazo-gigaset/common/common.py
@@ -1,5 +1,5 @@
 """
-Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 SPDX-License-Identifier: GPL-3.0-or-later
 
 Common code shared by the various wazo-gigaset plugins.
@@ -10,7 +10,6 @@ import os
 import logging
 import re
 import datetime
-from typing import Dict, Optional
 
 from provd.devices.pgasso import BasePgAssociator, DeviceSupport
 from provd.plugins import StandardPlugin, TemplatePluginHelper, FetchfwPluginHelper
@@ -108,7 +107,7 @@ class BaseGigasetPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == VENDOR:
             if model in self._models:
@@ -185,7 +184,7 @@ class BaseGigasetPlugin(StandardPlugin):
     def _check_config(self, raw_config):
         pass
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=True)
         return f'{formatted_mac}.xml'

--- a/plugins/wazo-grandstream/common/common.py
+++ b/plugins/wazo-grandstream/common/common.py
@@ -1,11 +1,10 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import synchronize
 from provd.devices.config import RawConfigError
@@ -91,7 +90,7 @@ class BaseGrandstreamPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Grandstream':
             if model in self._models:
@@ -160,7 +159,7 @@ class BaseGrandstreamPlugin(StandardPlugin):
 
     http_dev_info_extractor = BaseGrandstreamHTTPDeviceInfoExtractor()
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
         return f'cfg{formatted_mac}.xml'
@@ -253,14 +252,14 @@ class BaseGrandstreamPlugin(StandardPlugin):
                 logger.info('Unsupported funckey type: %s', funckey_type)
                 continue
             start_p_code = start_code + (i_funckey_no - 1) * 5
-            type_code = 'P{}'.format(start_p_code)
+            type_code = f'P{start_p_code}'
             lines.append((type_code, FUNCKEY_TYPES[funckey_type]))
-            line_code = 'P{}'.format(start_p_code + 1)
+            line_code = f'P{start_p_code + 1}'
             lines.append((line_code, int(funckey_dict['line']) - 1))
             if 'label' in funckey_dict:
-                label_code = 'P{}'.format(start_p_code + 2)
+                label_code = f'P{start_p_code + 2}'
                 lines.append((label_code, funckey_dict['label']))
-            value_code = 'P{}'.format(start_p_code + 3)
+            value_code = f'P{start_p_code + 3}'
             lines.append((value_code, funckey_dict['value']))
         raw_config['XX_mpk'] = lines
 

--- a/plugins/wazo-grandstream/common_ata/common.py
+++ b/plugins/wazo-grandstream/common_ata/common.py
@@ -1,11 +1,10 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import synchronize
 from provd.devices.config import RawConfigError
@@ -75,7 +74,7 @@ class BaseGrandstreamPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Grandstream':
             if model in self._models:
@@ -117,7 +116,7 @@ class BaseGrandstreamPlugin(StandardPlugin):
 
     http_dev_info_extractor = BaseGrandstreamHTTPDeviceInfoExtractor()
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=False)
         return f'cfg{formatted_mac}.xml'

--- a/plugins/wazo-htek/common/common.py
+++ b/plugins/wazo-htek/common/common.py
@@ -1,11 +1,10 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -64,7 +63,7 @@ class BaseHtekPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Htek':
             if model in self._model_versions:
@@ -326,7 +325,7 @@ class BaseHtekPlugin(StandardPlugin):
     def _add_xivo_phonebook_url(self, raw_config):
         plugins.add_xivo_phonebook_url(raw_config, 'htek', entry_point='lookup')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'cfg{formatted_mac}.xml'

--- a/plugins/wazo-jitsi/1/entry.py
+++ b/plugins/wazo-jitsi/1/entry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 import os.path
 import re
-from typing import Any, Dict, Optional
 
 from provd.devices.config import RawConfigError
 from provd.devices.pgasso import BasePgAssociator, DeviceSupport
@@ -66,7 +65,7 @@ class JitsiHTTPDeviceInfoExtractor:
             }
         return None
 
-    def _extract_from_args(self, args: Dict[bytes, Any], dev_info):
+    def _extract_from_args(self, args: dict[bytes, Any], dev_info):
         if 'uuid' in args:
             try:
                 dev_info['uuid'] = norm_uuid(args[b'uuid'][0].decode('ascii'))
@@ -76,7 +75,7 @@ class JitsiHTTPDeviceInfoExtractor:
 
 class JitsiPgAssociator(BasePgAssociator):
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == model == 'Jitsi':
             if version.startswith('1.'):

--- a/plugins/wazo-panasonic/common/common.py
+++ b/plugins/wazo-panasonic/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import synchronize
 from provd.devices.config import RawConfigError
@@ -71,7 +70,7 @@ class BasePanasonicPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Panasonic':
             if model in self._models:
@@ -103,7 +102,7 @@ class BasePanasonicPlugin(StandardPlugin):
 
     http_dev_info_extractor = BasePanasonicHTTPDeviceInfoExtractor()
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=True)
         return f'Config{formatted_mac}.cfg'
@@ -112,7 +111,7 @@ class BasePanasonicPlugin(StandardPlugin):
         if 'http_port' not in raw_config:
             raise RawConfigError('only support configuration via HTTP')
 
-    def _check_device(self, device: Dict[str, str]):
+    def _check_device(self, device: dict[str, str]):
         if 'mac' not in device:
             raise Exception('MAC address needed for device configuration')
 

--- a/plugins/wazo-patton/common/common.py
+++ b/plugins/wazo-patton/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ import os.path
 import re
 
 from operator import itemgetter
-from typing import Dict, Optional
 
 from provd import synchronize, tzinform
 from provd.plugins import (
@@ -39,7 +38,7 @@ class BasePattonHTTPDeviceInfoExtractor:
             return self._extract_from_ua(ua.decode('ascii'))
         return None
 
-    def _extract_from_ua(self, ua: str) -> Optional[Dict[str, str]]:
+    def _extract_from_ua(self, ua: str) -> dict[str, str] | None:
         # HTTP User-Agent:
         #   "SmartNode (Model:SN4112/JS/EUI; Serial:00A0BA08933C;
         #   Software Version:R6.2 2012-09-11 H323 SIP FXS FXO; Hardware Version:4.4)"
@@ -67,7 +66,7 @@ class BasePattonPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Patton':
             if model in self._models:
@@ -339,7 +338,7 @@ class BasePattonPlugin(StandardPlugin):
 
     _SENSITIVE_FILENAME_REGEX = re.compile(r'^[0-9a-f]{12}\.cfg$')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}.cfg'
 

--- a/plugins/wazo-polycom/common-v3/common.py
+++ b/plugins/wazo-polycom/common-v3/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@ import logging
 import re
 import os.path
 from operator import itemgetter
-from typing import Dict, Optional
 from xml.sax.saxutils import escape
 from provd import tzinform
 from provd import synchronize
@@ -61,7 +60,7 @@ class BasePolycomHTTPDeviceInfoExtractor:
                 return dev_info
         return None
 
-    def _extract_info_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_info_from_ua(self, ua: str, dev_info: dict[str, str]):
         # Note: depending on the boot step, the version number will either
         # be the BootROM version (first few requests) or the SIP application
         # version (later on in the boot process).
@@ -83,7 +82,7 @@ class BasePolycomHTTPDeviceInfoExtractor:
             dev_info['model'] = raw_model.replace('_', '')
             dev_info['version'] = raw_version
 
-    def _extract_mac_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_mac_from_path(self, path: str, dev_info: dict[str, str]):
         # Extract the MAC address from the requested path if possible
         m = self._PATH_REGEX.search(path)
         if m:
@@ -104,7 +103,7 @@ class BasePolycomPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Polycom':
             if model in self._models:
@@ -236,9 +235,7 @@ class BasePolycomPlugin(StandardPlugin):
             keynum = int(funckey_no)
             if keynum <= nb_keys:
                 value = funckey_dict['value']
-                lines.append(
-                    'attendant.resourceList.%s.address="%s"' % (funckey_no, value)
-                )
+                lines.append(f'attendant.resourceList.{funckey_no}.address="{value}"')
                 lines.append(
                     'attendant.resourceList.%s.label="%s"'
                     % (funckey_no, escape(funckey_dict.get('label', value)))
@@ -274,7 +271,7 @@ class BasePolycomPlugin(StandardPlugin):
             if voicemail:
                 line.setdefault('voicemail', voicemail)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}-user.cfg'

--- a/plugins/wazo-polycom/common/common.py
+++ b/plugins/wazo-polycom/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@ import logging
 import re
 import os.path
 from operator import itemgetter
-from typing import Dict, Optional, Union
 from xml.sax.saxutils import escape
 from provd import plugins
 from provd import tzinform
@@ -60,7 +59,7 @@ class BasePolycomHTTPDeviceInfoExtractor:
                 return dev_info
         return None
 
-    def _extract_info_from_ua(self, ua: str, dev_info: Dict[str, str]):
+    def _extract_info_from_ua(self, ua: str, dev_info: dict[str, str]):
         # Note: depending on the boot step, the version number will either
         # be the BootROM version (first few requests) or the SIP application
         # version (later on in the boot process).
@@ -84,7 +83,7 @@ class BasePolycomHTTPDeviceInfoExtractor:
             dev_info['model'] = model.replace('_', '')
             dev_info['version'] = version
 
-    def _extract_mac_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_mac_from_path(self, path: str, dev_info: dict[str, str]):
         # Extract the MAC address from the requested path if possible
         m = self._PATH_REGEX.search(path)
         if m:
@@ -103,8 +102,8 @@ class BasePolycomPgAssociator(BasePgAssociator):
         self._models = models
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
-    ) -> Union[DeviceSupport]:
+        self, vendor: str, model: str | None, version: str | None
+    ) -> DeviceSupport:
         if vendor == 'Polycom':
             if model in self._models:
                 return DeviceSupport.COMPLETE + 1
@@ -313,7 +312,7 @@ class BasePolycomPlugin(StandardPlugin):
 
     _SENSITIVE_FILENAME_REGEX = re.compile(r'^[0-9a-f]{12}-user\.cfg$')
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}-user.cfg'
@@ -322,7 +321,7 @@ class BasePolycomPlugin(StandardPlugin):
         if 'http_port' not in raw_config:
             raise RawConfigError('only support configuration via HTTP')
 
-    def _check_device(self, device: Dict[str, str]):
+    def _check_device(self, device: dict[str, str]):
         if 'mac' not in device:
             raise Exception('MAC address needed for device configuration')
 

--- a/plugins/wazo-snom/common/common.py
+++ b/plugins/wazo-snom/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ import os.path
 import re
 import glob
 from operator import itemgetter
-from typing import Dict, Optional
 
 from pkg_resources import parse_version
 from xml.sax.saxutils import escape
@@ -82,7 +81,7 @@ class BaseSnomHTTPDeviceInfoExtractor:
             }
         return None
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         m = self._PATH_REGEX.search(path)
         if m:
             raw_mac = m.group(1)
@@ -95,7 +94,7 @@ class BaseSnomPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Snom':
             if version is None:

--- a/plugins/wazo-snom/common_dect/common.py
+++ b/plugins/wazo-snom/common_dect/common.py
@@ -1,11 +1,10 @@
-# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import os.path
 import re
-from typing import Dict, Optional
 
 from pkg_resources import parse_version
 from provd import plugins
@@ -63,7 +62,7 @@ class BaseSnomDECTHTTPDeviceInfoExtractor:
             }
         return None
 
-    def _extract_from_path(self, path: str, dev_info: Dict[str, str]):
+    def _extract_from_path(self, path: str, dev_info: dict[str, str]):
         m = self._PATH_REGEX.search(path)
         if m:
             raw_mac = m.group(1)
@@ -76,7 +75,7 @@ class BaseSnomPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Snom':
             if version is None:

--- a/plugins/wazo-technicolor/common/common.py
+++ b/plugins/wazo-technicolor/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@ import logging
 import os.path
 import re
 import time
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -81,7 +80,7 @@ class BaseTechnicolorPgAssociator(BasePgAssociator):
         self._version = version
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Technicolor':
             if model == self._model:
@@ -307,7 +306,7 @@ class BaseTechnicolorPlugin(StandardPlugin):
             raw_config, 'thomson', entry_point='lookup', qs_suffix='term=#SEARCH'
         )
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='', uppercase=True)
         return f'{self._FILENAME_PREFIX}_{formatted_mac}.txt'

--- a/plugins/wazo-yealink/common/common.py
+++ b/plugins/wazo-yealink/common/common.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -95,7 +94,7 @@ class BaseYealinkHTTPDeviceInfoExtractor:
                 return device_info
         return None
 
-    def _extract_from_path(self, request: Request) -> Dict[str, str] | None:
+    def _extract_from_path(self, request: Request) -> dict[str, str] | None:
         if request.path.startswith(b'/001565'):
             raw_mac = request.path[1:-4]
             try:
@@ -115,7 +114,7 @@ class BaseYealinkPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Yealink':
             if model in self._model_versions:
@@ -473,7 +472,7 @@ class BaseYealinkPlugin(StandardPlugin):
             raw_config, 'yealink', entry_point='lookup', qs_suffix='term=#SEARCH'
         )
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-yealink/v73/entry.py
+++ b/plugins/wazo-yealink/v73/entry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ class YealinkPlugin(common_globals['BaseYealinkPlugin']):
     _COMMON_FILES = COMMON_FILES
 
     def configure_common(self, raw_config):
-        super(YealinkPlugin, self).configure_common(raw_config)
+        super().configure_common(raw_config)
         for (
             filename,
             fw_filename,

--- a/plugins/wazo-yealink/v80/entry.py
+++ b/plugins/wazo-yealink/v80/entry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -71,7 +71,7 @@ class YealinkPlugin(common_globals['BaseYealinkPlugin']):
     _COMMON_FILES = COMMON_FILES
 
     def configure_common(self, raw_config):
-        super(YealinkPlugin, self).configure_common(raw_config)
+        super().configure_common(raw_config)
         for (
             filename,
             fw_filename,

--- a/plugins/wazo-yealink/v81/entry.py
+++ b/plugins/wazo-yealink/v81/entry.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -70,7 +70,7 @@ class YealinkPlugin(common_globals['BaseYealinkPlugin']):
     _COMMON_FILES = COMMON_FILES
 
     def configure_common(self, raw_config):
-        super(YealinkPlugin, self).configure_common(raw_config)
+        super().configure_common(raw_config)
         for (
             filename,
             fw_filename,

--- a/plugins/wazo-yealink/v82/common.py
+++ b/plugins/wazo-yealink/v82/common.py
@@ -1,11 +1,10 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import os.path
 import re
-from typing import Dict, Optional
 
 from provd import plugins, synchronize, tzinform
 from provd.devices.config import RawConfigError
@@ -106,7 +105,7 @@ class BaseYealinkPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Yealink':
             if model in self._model_versions:
@@ -460,7 +459,7 @@ class BaseYealinkPlugin(StandardPlugin):
             raw_config, 'yealink', entry_point='lookup', qs_suffix='term=#SEARCH'
         )
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-yealink/v83/common.py
+++ b/plugins/wazo-yealink/v83/common.py
@@ -1,11 +1,10 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -118,7 +117,7 @@ class BaseYealinkPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Yealink':
             if model in self._model_versions:
@@ -529,7 +528,7 @@ class BaseYealinkPlugin(StandardPlugin):
         if hasattr(plugins, 'add_wazo_phoned_user_service_url'):
             plugins.add_wazo_phoned_user_service_url(raw_config, 'yealink', service)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-yealink/v83/entry.py
+++ b/plugins/wazo-yealink/v83/entry.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -88,7 +88,7 @@ class YealinkPlugin(common_globals['BaseYealinkPlugin']):
     _COMMON_FILES = COMMON_FILES
 
     def configure_common(self, raw_config):
-        super(YealinkPlugin, self).configure_common(raw_config)
+        super().configure_common(raw_config)
         for dect_info in COMMON_FILES_DECT:
             tpl = self._tpl_helper.get_template(f'common/{dect_info["tpl_filename"]}')
             dst = os.path.join(self._tftpboot_dir, dect_info['filename'])

--- a/plugins/wazo-yealink/v83/tests/test_common.py
+++ b/plugins/wazo-yealink/v83/tests/test_common.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from textwrap import dedent
@@ -97,7 +97,7 @@ class TestInfoExtraction:
         for path, mac in macs_from_paths.items():
             assert self.http_info_extractor._do_extract(
                 self._mock_request(path=path)
-            ) == {u'mac': mac}
+            ) == {'mac': mac}
 
         assert self.http_info_extractor._do_extract(
             self._mock_request(path=b'/y000000000025.cfg')

--- a/plugins/wazo-yealink/v84/common.py
+++ b/plugins/wazo-yealink/v84/common.py
@@ -1,11 +1,10 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -103,7 +102,7 @@ class BaseYealinkPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Yealink':
             if model in self._model_versions:
@@ -458,7 +457,7 @@ class BaseYealinkPlugin(StandardPlugin):
         if hasattr(plugins, 'add_wazo_phoned_user_service_url'):
             plugins.add_wazo_phoned_user_service_url(raw_config, 'yealink', service)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-yealink/v84/tests/test_common.py
+++ b/plugins/wazo-yealink/v84/tests/test_common.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from textwrap import dedent
@@ -98,7 +98,7 @@ class TestInfoExtraction:
             self.http_info_extractor._do_extract(self._mock_request(path=path))
             assert self.http_info_extractor._do_extract(
                 self._mock_request(path=path)
-            ) == {u'mac': mac}
+            ) == {'mac': mac}
 
     @patch('v84.common.logger')
     def test_invalid_mac(self, mocked_logger):
@@ -158,7 +158,7 @@ class TestPluginAssociation:
         assert plugin_associator._do_associate('', '', '') == DeviceSupport.IMPROBABLE
 
 
-class TestPlugin(object):
+class TestPlugin:
     @patch('v84.common.FetchfwPluginHelper')
     def test_init(self, fetch_fw, v84_entry):
         fetch_fw.return_value.services.return_value = sentinel.fetchfw_services

--- a/plugins/wazo-yealink/v85/common.py
+++ b/plugins/wazo-yealink/v85/common.py
@@ -1,11 +1,10 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -100,7 +99,7 @@ class BaseYealinkPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Yealink':
             if model in self._model_versions:
@@ -498,7 +497,7 @@ class BaseYealinkPlugin(StandardPlugin):
         if hasattr(plugins, 'add_wazo_phoned_user_service_url'):
             plugins.add_wazo_phoned_user_service_url(raw_config, 'yealink', service)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-yealink/v85/entry.py
+++ b/plugins/wazo-yealink/v85/entry.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -123,7 +123,7 @@ class YealinkPlugin(common_globals['BaseYealinkPlugin']):
     _COMMON_FILES = COMMON_FILES
 
     def configure_common(self, raw_config):
-        super(YealinkPlugin, self).configure_common(raw_config)
+        super().configure_common(raw_config)
         for dect_info in COMMON_FILES_DECT:
             tpl = self._tpl_helper.get_template(f'common/{dect_info["tpl_filename"]}')
             dst = os.path.join(self._tftpboot_dir, dect_info['filename'])

--- a/plugins/wazo-yealink/v86/common.py
+++ b/plugins/wazo-yealink/v86/common.py
@@ -1,11 +1,10 @@
-# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 import logging
 import re
 import os.path
-from typing import Dict, Optional
 
 from provd import plugins
 from provd import tzinform
@@ -81,7 +80,7 @@ class BaseYealinkHTTPDeviceInfoExtractor:
                 return device_info
         return None
 
-    def _extract_from_path(self, request: Request) -> Optional[Dict[str, str]]:
+    def _extract_from_path(self, request: Request) -> dict[str, str] | None:
         if request.path[1:7] in KNOWN_MAC_PREFIXES:
             raw_mac = request.path[1:-4]
             try:
@@ -99,7 +98,7 @@ class BaseYealinkPgAssociator(BasePgAssociator):
         self._model_versions = model_versions
 
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Yealink':
             if model in self._model_versions:
@@ -489,7 +488,7 @@ class BaseYealinkPlugin(StandardPlugin):
         if hasattr(plugins, 'add_wazo_phoned_user_service_url'):
             plugins.add_wazo_phoned_user_service_url(raw_config, 'yealink', service)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='')
         return f'{formatted_mac}.cfg'

--- a/plugins/wazo-yealink/v86/entry.py
+++ b/plugins/wazo-yealink/v86/entry.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -114,7 +114,7 @@ class YealinkPlugin(common_globals['BaseYealinkPlugin']):
     _COMMON_FILES = COMMON_FILES
 
     def configure_common(self, raw_config):
-        super(YealinkPlugin, self).configure_common(raw_config)
+        super().configure_common(raw_config)
         for dect_info in COMMON_FILES_DECT:
             tpl = self._tpl_helper.get_template(f'common/{dect_info["tpl_filename"]}')
             dst = os.path.join(self._tftpboot_dir, dect_info['filename'])

--- a/plugins/wazo-zenitel/common/common.py
+++ b/plugins/wazo-zenitel/common/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2023 The Wazo Authors  (see the AUTHORS file)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from operator import itemgetter
-from typing import Dict, Optional
 
 from provd.devices.config import RawConfigError
 from provd.devices.pgasso import BasePgAssociator, DeviceSupport
@@ -67,7 +66,7 @@ class BaseZenitelTFTPDeviceInfoExtractor:
 
 class BaseZenitelPgAssociator(BasePgAssociator):
     def _do_associate(
-        self, vendor: str, model: Optional[str], version: Optional[str]
+        self, vendor: str, model: str | None, version: str | None
     ) -> DeviceSupport:
         if vendor == 'Zenitel':
             if model == 'IP station':
@@ -182,7 +181,7 @@ class BaseZenitelPlugin(StandardPlugin):
                 logger.info('Out of range funckey no: %s', funckey_no)
         raw_config['XX_fkeys'] = '\n'.join(' ' + s for s in lines)
 
-    def _dev_specific_filename(self, device: Dict[str, str]) -> str:
+    def _dev_specific_filename(self, device: dict[str, str]) -> str:
         # Return the device specific filename (not pathname) of device
         formatted_mac = format_mac(device['mac'], separator='_', uppercase=False)
         return f'ipst_config_{formatted_mac}.cfg'


### PR DESCRIPTION
pyupgrade was limited to py37 features as we need to remain compatible with Python 3.7 for plugins for now.
Annotations can be updated as they are lazy and not used at runtime.