### PR TITLE
Gigaset: fix line attribution

### DIFF
--- a/plugins/wazo-gigaset/N510/templates/base.tpl
+++ b/plugins/wazo-gigaset/N510/templates/base.tpl
@@ -27,12 +27,23 @@
 {% for line_no, line in sip_lines.items() %}
     {%- if line_no == '1' %}
     {%- set line_suffix = '' %}
+    {%- set line_outgoing = '01' %}
     {%- else %}
     {%- set line_suffix = '_' + line_no %}
+    {%- set line_outgoing = '0' + line_no %}
+    {%- endif %}
+    {%- if line_no == '3' %}
+    {%- set line_outgoing = '04' %}
+    {%- elif line_no == '4' %}
+    {%- set line_outgoing = '08' %}
+    {%- elif line_no == '5' %}
+    {%- set line_outgoing = '10' %}
+    {%- elif line_no == '6' %}
+    {%- set line_outgoing = '20' %}
     {%- endif %}
     <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].aucAccountName[0]" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
-    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiSendMask" class="symb_item" value="0x0{{ "%x"|format(line_no|int()) }}"/>
-    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiReceiveMask" class="symb_item" value="0x0{{ "%x"|format(line_no|int()) }}"/>
+    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiSendMask" class="symb_item" value="0x{{ line_outgoing }}"/>
+    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiReceiveMask" class="symb_item" value="0x{{ line_outgoing }}"/>
     <SYMB_ITEM ID="BS_IP_Data1.aucS_SIP_ACCOUNT_NAME_{{ line_no }}" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
     <SYMB_ITEM ID="BS_IP_Data1.aucS_SIP_DISPLAYNAME{{ line_suffix }}" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
     <SYMB_ITEM ID="BS_IP_Data3.aucS_SIP_LOGIN_ID{{ line_suffix }}" class="symb_item" value='"{{ line['auth_username']|d(line['username']) }}"'/>


### PR DESCRIPTION
The options `uiSendMask` and `uiReceiveMask` must respect a good values attribution.
Gigaset documentation : 
```
> Values:
- (0000 0000) “0x00” = no HS
- (0000 0001) “0x01” = HS1
- (0000 0010) “0x02” = HS2
- (0000 0100) “0x04” = HS3
- (0000 1000) “0x08” = HS4
- (0001 0000) “0x10” = HS5
- (0010 0000) “0x20” = HS6

``` 