### PR TITLE
Proper one-to-one assignement on Gigaset N510 (v2)

### DIFF
--- a/plugins/wazo-gigaset/N510/plugin-info
+++ b/plugins/wazo-gigaset/N510/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.11",
+    "version": "0.1.12",
     "description": "Plugin for Gigaset N510 IP",
     "description_fr": "Greffon pour Gigaset N510 IP",
     "capabilities": {

--- a/plugins/wazo-gigaset/N510/templates/base.tpl
+++ b/plugins/wazo-gigaset/N510/templates/base.tpl
@@ -31,8 +31,8 @@
     {%- set line_suffix = '_' + line_no %}
     {%- endif %}
     <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].aucAccountName[0]" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
-    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiSendMask" class="symb_item" value="0x0{{ "%x"|format(line_no|int()) }}"/>
-    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiReceiveMask" class="symb_item" value="0x0{{ "%x"|format(line_no|int()) }}"/>
+    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiSendMask" class="symb_item" value="0x{{ "%x"|format(2 ** (line_no|int() - 1)) }}"/>
+    <SYMB_ITEM ID="BS_Accounts.astAccounts[{{ line_no|int() - 1 }}].uiReceiveMask" class="symb_item" value="0x{{ "%x"|format(2 ** (line_no|int() - 1)) }}"/>
     <SYMB_ITEM ID="BS_IP_Data1.aucS_SIP_ACCOUNT_NAME_{{ line_no }}" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
     <SYMB_ITEM ID="BS_IP_Data1.aucS_SIP_DISPLAYNAME{{ line_suffix }}" class="symb_item" value='"{{ line['display_name'] }} {{ line['number'] }}"'/>
     <SYMB_ITEM ID="BS_IP_Data3.aucS_SIP_LOGIN_ID{{ line_suffix }}" class="symb_item" value='"{{ line['auth_username']|d(line['username']) }}"'/>


### PR DESCRIPTION
uiSendMask and uiReceiveMask are bitmasks so power of 2 must be used to do 1:1 assignment properly