### PR TITLE
Update snom.conf

### DIFF
--- a/dhcp/dhcp/dhcpd_update/snom.conf
+++ b/dhcp/dhcp/dhcpd_update/snom.conf
@@ -71,6 +71,11 @@ group {
         log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Snom D712"));
     }
 
+    class "SnomD713" {
+        match if option vendor-class-identifier = "snomD713";
+        log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Snom D713"));
+    }
+
     class "Snom715" {
         match if option vendor-class-identifier = "snom715";
         log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Snom 715"));


### PR DESCRIPTION
Add Snom D713 conf Block in order to allow wazo to create device for device provisionning.

Issue :

When plug a snom d713, wazo dhcp give a proper ip address but don't create device in device menu, so phone can't be auto-configured.

After changes, device is properly created with greffon and config device