### PR TITLE
Pull request for WAZO-3532-use-main-proxy-ip

### DIFF
--- a/plugins/wazo_digium/common/common.py
+++ b/plugins/wazo_digium/common/common.py
@@ -149,11 +149,12 @@ class BaseDigiumPlugin(StandardPlugin):
             raise Exception('MAC address needed to configure device')
 
     def _get_main_proxy_ip(self, raw_config):
-        if raw_config['sip_lines']:
-            line_no = min(int(x) for x in list(raw_config['sip_lines']))
-            line_no = str(line_no)
-            return raw_config['sip_lines'][line_no]['proxy_ip']
-        return raw_config['ip']
+        if not raw_config['sip_lines']:
+            raise Exception('Device need to have at least one line')
+
+        line_no = min(int(x) for x in list(raw_config['sip_lines']))
+        line_no = str(line_no)
+        return raw_config['sip_lines'][line_no]['proxy_ip']
 
     def _add_server_url(self, raw_config):
         if raw_config.get('http_base_url'):

--- a/plugins/wazo_digium/v1_4_0_0/plugin-info
+++ b/plugins/wazo_digium/v1_4_0_0/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Plugin for Digium D40, D50 and D70 in version 1.4.0.0.",
     "description_fr": "Greffon pour Digium D40, D50 et D70 en version 1.4.0.0.",
     "capabilities": {

--- a/plugins/wazo_digium/v2_2_1_8/plugin-info
+++ b/plugins/wazo_digium/v2_2_1_8/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Plugin for Digium D4X, D50, D6X and D70 in version 2.2.1.8.",
     "description_fr": "Greffon pour Digium D4X, D50, D6X et D70 en version 2.2.1.8.",
     "capabilities": {

--- a/plugins/wazo_digium/v2_8_1/plugin-info
+++ b/plugins/wazo_digium/v2_8_1/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Plugin for Digium D4X, D50, D6X and D70 in version 2.8.1.",
     "description_fr": "Greffon pour Digium D4X, D50, D6X et D70 en version 2.8.1.",
     "capabilities": {

--- a/plugins/wazo_yealink/v83/plugin-info
+++ b/plugins/wazo_yealink/v83/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.5",
+    "version": "1.4.6",
     "description": "Plugin for Yealink for CP960, T2X, T4X, T5X, W60 and W80 series in version V83.",
     "description_fr": "Greffon pour Yealink pour les series CP960, T2X, T4X, T5X, W60 et W80 en version V83.",
     "vendor" : "Yealink",

--- a/plugins/wazo_yealink/v83/templates/base.tpl
+++ b/plugins/wazo_yealink/v83/templates/base.tpl
@@ -21,7 +21,9 @@ distinctive_ring_tones.alert_info.7.ringer = 7
 distinctive_ring_tones.alert_info.8.ringer = 8
 
 features.caller_name_type_on_dialing = 1
-features.action_uri_limit_ip = {{ ip }}
+{% for line_no, line in XX_sip_lines.items() if line -%}
+features.action_uri_limit_ip = {{ line['proxy_ip'] }}
+{% endfor -%}
 features.show_action_uri_option = 0
 
 local_time.date_format = 2

--- a/plugins/wazo_yealink/v86/plugin-info
+++ b/plugins/wazo_yealink/v86/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Plugin for Yealink for CP920, CP925, T27G, T3X, T4X and T5X series in version 86.",
     "description_fr": "Greffon pour Yealink pour les series CP920, CP925, T27G, T3X, T4X et T5X en version 86.",
     "vendor" : "Yealink",

--- a/plugins/wazo_yealink/v86/templates/base.tpl
+++ b/plugins/wazo_yealink/v86/templates/base.tpl
@@ -25,7 +25,9 @@ features.text_message.enable = 0
 features.text_message_popup.enable = 0
 features.config_dsskey_length = 1
 features.dnd.large_icon.enable = 1
-features.action_uri_limit_ip = {{ ip }}
+{% for line_no, line in XX_sip_lines.items() if line -%}
+features.action_uri_limit_ip = {{ line['proxy_ip'] }}
+{% endfor -%}
 features.show_action_uri_option = 0
 
 local_time.date_format = 2


### PR DESCRIPTION
## digium: raise exception if no line is configured

why: we want to remove usage of raw_config['ip'] key in order to
deprecate this key. Moreover, a device without line doesn't make sense.
note: autoprov have one sip_line

## yealink: use proxy_ip for action_uri_limit_ip

why:
- we want to remove usage of raw_config['ip'] key in order to deprecate
  this key.
- IP is the provisioning server, and action_uri_limit_ip need to have
  the PBX server.

note: taking the last line proxy_ip is only for convenience and have the
same issue than taking the first one