### PR TITLE
Fix function keys page attribution

### DIFF
--- a/plugins/wazo_fanvil/common/templates/base-V-series.tpl
+++ b/plugins/wazo_fanvil/common/templates/base-V-series.tpl
@@ -160,9 +160,9 @@
         {% if loop.index0 != 0 -%}
         </dssSide>
         {%- endif %}
-        <dssSide index="{{ page + 1 }}">
+        <dssSide index="{{ page }}">
         {%- endif %}
-            <Fkey index="{{ index + 1}}">
+            <Fkey index="{{ index }}">
             {%- if sip_lines %}
             {% for line_no in sip_lines -%}
                 <Type>{{ fkey['type'] }}</Type>

--- a/plugins/wazo_fanvil/common/templates/base-V67.tpl
+++ b/plugins/wazo_fanvil/common/templates/base-V67.tpl
@@ -310,9 +310,9 @@
         {% if loop.index0 != 0 -%}
         </internal>
         {%- endif %}
-        <internal index="{{ page + 1 }}">
+        <internal index="{{ page }}">
         {%- endif %}
-            <Fkey index="{{ index + 1}}">
+            <Fkey index="{{ index }}">
                 <Type>{{ fkey['type'] }}</Type>
                 <Value>{{ fkey['value'] }}</Value>
                 <Title>{{ fkey['title'] }}</Title>

--- a/plugins/wazo_fanvil/serie_v/entry.py
+++ b/plugins/wazo_fanvil/serie_v/entry.py
@@ -81,9 +81,9 @@ MODEL_FIRMWARE_MAPPING = {
 
 FUNCTION_KEYS_PER_PAGE = {
     'V67': 29,
-    'V65': 10,
-    'V64': 8,
-    'V62': 6,
+    'V65': 9,
+    'V64': 7,
+    'V62': 5,
 }
 
 

--- a/plugins/wazo_fanvil/serie_v/plugin-info
+++ b/plugins/wazo_fanvil/serie_v/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Plugin for Fanvil V6x series",
     "description_fr": "Greffon pour La serie V6x Fanvil",
     "vendor" : "Fanvil",


### PR DESCRIPTION
* fix templates for V6x
* fix number key by page (removing an entry for the page switch)

Tested on V65 (v2.12.16.4) and V67 (v2.6.6.201)