### PR TITLE
Revert Mitel 6.4.0 language-pack removal

### DIFF
--- a/plugins/wazo_aastra/v6_4_0_SP2/pkgs/pkgs.db
+++ b/plugins/wazo_aastra/v6_4_0_SP2/pkgs/pkgs.db
@@ -33,6 +33,13 @@ version: 6.4.0.140
 files: 6873i-fw
 install: 6873i-fw
 
+[pkg_lang]
+description: Language files
+description_fr: Fichiers de langue
+version: 6.4.0.140
+files: lang
+install: aastra-lang
+
 
 [install_6863i-fw]
 a-b: untar $FILE1
@@ -53,6 +60,10 @@ b-c: include *.st
 [install_6873i-fw]
 a-b: untar $FILE1
 b-c: include *.st
+
+[install_aastra-lang]
+a-b: untar $FILE1
+b-c: cp * i18n/
 
 
 [file_6863i-fw]
@@ -84,3 +95,9 @@ filename: 6873i.tar.gz
 url:
 size: 49339842
 sha1sum: c42142ea99b9fd8af8c0f8fb272c505f40845ae9
+
+[file_lang]
+filename: R500-6800-5801456REV00LangPacks3.zip
+url: https://www.mitel.com/-/media/mitel/file/zip/open-solutions/6867/r500-6800-5801456rev00langpacks1.zip
+size: 905670
+sha1sum: 931ca34c03f43713d59e7afe1f5cf5ca5e114b0a

--- a/plugins/wazo_aastra/v6_4_0_SP2/plugin-info
+++ b/plugins/wazo_aastra/v6_4_0_SP2/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Plugin for Aastra/Mitel 6863i, 6865i, 6867i, 6869i and 6873i in version 6.4.0 SP2",
     "description_fr": "Greffon pour Aastra/Mitel 6863i, 6865i, 6867i, 6869i et 6873i en version 6.4.0 SP2",
     "capabilities": {


### PR DESCRIPTION
It is still possible to load language pack files, so it probably is useful to keep the language pack file even if it's for 5.0 and not 6.4