### PR TITLE
Yealink v87 | Add DECT W70/W75/W80/W90 support

### DIFF
--- a/plugins/wazo_yealink/v87/common.py
+++ b/plugins/wazo_yealink/v87/common.py
@@ -48,7 +48,7 @@ KNOWN_MAC_PREFIXES = (
 class BaseYealinkHTTPDeviceInfoExtractor:
     _UA_REGEX_LIST = [
         re.compile(r'^[yY]ealink\s+SIP-(\w+)\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
-        re.compile(r'^[yY]ealink\s+(W90(?:DM|B))\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
+        re.compile(r'^[yY]ealink\s+(W[789][05](?:DM|B))\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
         re.compile(r'^[yY]ealink\s+SIP(?: VP)?-(\w+)\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
         re.compile(r'^[yY]ealink\s+(W60B)\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
         re.compile(r'(VP530P?|W60B)\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
@@ -78,6 +78,11 @@ class BaseYealinkHTTPDeviceInfoExtractor:
         #   "Yealink SIP-T77U 185.87.0.10 44:db:d2:bd:b5:69"
         #   "Yealink SIP-T85W 185.87.0.10 44:db:d2:67:58:4b"
         #   "Yealink SIP-T87W 185.87.0.10 44:db:d2:c9:73:b7"
+        #   "Yealink W90DM 130.87.0.10 80:5e:c0:d9:c7:44"
+        #   "Yealink W70B 146.87.0.15 80:5e:0c:1d:65:4e"
+        #   "Yealink W80B 103.87.0.10 24:9a:d8:d1:a6:31"
+        #   "Yealink W80DM 103.87.0.10 24:9a:d8:d1:a6:31"
+        #   "Yealink W75B 175.87.0.10 24:9a:d8:df:fb:11"
 
         for UA_REGEX in self._UA_REGEX_LIST:
             m = UA_REGEX.match(ua)
@@ -265,6 +270,13 @@ class BaseYealinkFunckeyPrefixIterator:
         'T87W': 95,
         'T88W': 95,
         'T88V': 95,
+        'W70B': 0,
+        'W75B': 0,
+        'W75DM': 0,
+        'W80DM': 0,
+        'W80B': 0,
+        'W90DM': 0,
+        'W90B': 0,
     }
     _NB_MEMORYKEY = {
         'CP920': 0,
@@ -308,6 +320,13 @@ class BaseYealinkFunckeyPrefixIterator:
         'T87W': 0,
         'T88W': 0,
         'T88V': 0,
+        'W70B': 0,
+        'W75B': 0,
+        'W75DM': 0,
+        'W80DM': 0,
+        'W80B': 0,
+        'W90DM': 0,
+        'W90B': 0,
     }
 
     class NullExpansionModule:
@@ -425,6 +444,13 @@ class BaseYealinkPlugin(StandardPlugin):
         'T87W': 16,
         'T88W': 16,
         'T88V': 16,
+        'W70B': 10,
+        'W75B': 0,
+        'W75DM': 20,
+        'W80DM': 30,
+        'W80B': 0,
+        'W90DM': 250,
+        'W90B': 0,
     }
     _SENSITIVE_FILENAME_REGEX = re.compile(r'^[0-9a-f]{12}\.cfg')
 

--- a/plugins/wazo_yealink/v87/entry.py
+++ b/plugins/wazo_yealink/v87/entry.py
@@ -20,9 +20,12 @@ execfile_('common.py', common_globals)  # type: ignore[name-defined]
 
 
 HANDSETS_FW = {
-    'w53h': 'W53H-88.85.0.20.rom',
-    'w56h': 'W56H-61.85.0.20.rom',
-    'w59r': 'W59R-115.85.0.20.rom',
+    'w56h': 'W56H-61.87.0.5.rom',
+    'w57r': 'W57R-118.87.0.5.rom',
+    'w59r': 'W59R-115.87.0.5.rom',
+    'w73h': 'W73H-116.87.0.5.rom',
+    'w74h': 'W74H-119.87.0.5.rom',
+    'w78h': 'W78H-16.87.0.5.rom',
     'cp930w': 'CP930W-87.85.0.20.rom',
     't41s_dd10k': 'T4S-ddphone-66.85.0.56.rom',
     't54w_dd10k': 'T54W-ddphone-96.85.0.65.rom ',
@@ -72,6 +75,41 @@ MODEL_INFO = {
     'AX86R': {
         'version': '180.87.0.5',
         'firmware': 'AX83(AX83,AX86)-180.87.0.5.rom',
+    },
+    'W70B': {
+        'version': '146.87.0.15',
+        'firmware': 'W70B-146.87.0.15.rom',
+        'handsets_fw': HANDSETS_FW,
+    },
+    'W75DM': {
+        'version': '175.87.0.10',
+        'firmware': 'W75DM-175.87.0.10.rom',
+        'handsets_fw': HANDSETS_FW,
+    },
+    'W75B': {
+        'version': '175.87.0.10',
+        'firmware': 'W75DM-175.87.0.10.rom',  # Yealink Inject W75B fw inside W75DM
+        'handsets_fw': HANDSETS_FW,
+    },
+    'W80DM': {
+        'version': '103.87.0.10',
+        'firmware': '$PN-103.87.0.10.rom',
+        'handsets_fw': HANDSETS_FW,
+    },
+    'W80B': {
+        'version': '103.87.0.10',
+        'firmware': '$PN-103.87.0.10.rom',
+        'handsets_fw': HANDSETS_FW,
+    },
+    'W90DM': {
+        'version': '130.87.0.10',
+        'firmware': '$PN-130.87.0.10.rom',  # $PN = Product Name, i.e W90DM
+        'handsets_fw': HANDSETS_FW,
+    },
+    'W90B': {
+        'version': '130.87.0.10',
+        'firmware': '$PN-130.87.0.10.rom',  # $PN = Product Name, i.e W90B
+        'handsets_fw': HANDSETS_FW,
     },
 }
 

--- a/plugins/wazo_yealink/v87/pkgs/pkgs.db
+++ b/plugins/wazo_yealink/v87/pkgs/pkgs.db
@@ -12,25 +12,81 @@ version: 180.87.0.5
 files: AX8X-fw
 install: yealink-fw
 
-[pkg_W53H-fw]
-description: Firmware for Yealink W53H handset
-description_fr: Micrologiciel pour le combiné Yealink W53H
-version: 88.85.0.20
-files: W53H-fw
+[pkg_W70B-fw]
+description: Firmware for Yealink W70B
+description_fr: Micrologiciel pour Yealink W70B
+version: 146.87.0.15
+files: W70B-fw
+install: yealink-fw
+
+[pkg_W80B-fw]
+description: Firmware for Yealink W80B
+description_fr: Micrologiciel pour Yealink W80B
+version: 103.87.0.10
+files: W80B-fw
+install: yealink-fw
+
+[pkg_W80DM-fw]
+description: Firmware for Yealink W80DM
+description_fr: Micrologiciel pour Yealink W80DM
+version: 103.87.0.10
+files: W80DM-fw
+install: yealink-fw
+
+[pkg_W75DM-fw]
+description: Firmware for Yealink W75DM and W75B
+description_fr: Micrologiciel pour Yealink W75DM et W75B
+version: 175.87.0.10
+files: W75DM-fw
+install: yealink-fw
+
+[pkg_W90DM-fw]
+description: Firmware for Yealink W90DM
+description_fr: Micrologiciel pour Yealink W90DM
+version: 130.87.0.10
+files: W90DM-fw
 install: yealink-fw
 
 [pkg_W56H-fw]
 description: Firmware for Yealink W56H handset
 description_fr: Micrologiciel pour le combiné Yealink W56H
-version: 61.85.0.20
+version: 61.87.0.5
 files: W56H-fw
+install: yealink-fw
+
+[pkg_W57R-fw]
+description: Firmware for Yealink W57R handset
+description_fr: Micrologiciel pour le combiné Yealink W57R
+version: 118.87.0.5
+files: W57R-fw
 install: yealink-fw
 
 [pkg_W59R-fw]
 description: Firmware for Yealink W59R handset
 description_fr: Micrologiciel pour le combiné Yealink W59R
-version: 115.85.0.20
+version: 115.87.0.5
 files: W59R-fw
+install: yealink-fw
+
+[pkg_W73H-fw]
+description: Firmware for Yealink W73H handset
+description_fr: Micrologiciel pour le combiné Yealink W73H
+version: 116.87.0.5
+files: W73H-fw
+install: yealink-fw
+
+[pkg_W74H-fw]
+description: Firmware for Yealink W74H handset
+description_fr: Micrologiciel pour le combiné Yealink W74H
+version: 119.87.0.5
+files: W74H-fw
+install: yealink-fw
+
+[pkg_W78H-fw]
+description: Firmware for Yealink W78H handset
+description_fr: Micrologiciel pour le combiné Yealink W78H
+version: 16.87.0.5
+files: W78H-fw
 install: yealink-fw
 
 [pkg_T4S-ddphone-fw]
@@ -63,23 +119,71 @@ url: http://provd.wazo.community/firmwares/yealink/AX83(AX83,AX86)-180.87.0.5.ro
 size: 38007952
 sha1sum: 9a71f73be9fcf63ace754a94932111c1c3c29684
 
-[file_W53H-fw]
-filename: W53H-88.85.0.20.rom
-url: http://provd.wazo.community/firmwares/yealink/W53H-88.85.0.20.rom
-size: 2631680
-sha1sum: 8184fdfadbceac79e6256e7f0f70ac0d1832f9a9
+[file_W70B-fw]
+filename: W70B-146.87.0.15.rom
+url: http://provd.wazo.community/firmwares/yealink/W70B-146.87.0.15.rom
+size: 22066224
+sha1sum: 215d69345c9318206bf8dad2e6864be16990c836
+
+[file_W80B-fw]
+filename: W80B-103.87.0.10.rom
+url: http://provd.wazo.community/firmwares/yealink/W80B-103.87.0.10.rom
+size: 27997808
+sha1sum: c932819fe6d991804acc63e4ec0da4b094078d0c
+
+[file_W80DM-fw]
+filename: W80DM-103.87.0.10.rom
+url: http://provd.wazo.community/firmwares/yealink/W80DM-103.87.0.10.rom
+size: 45266400
+sha1sum: 4d6dd50cb4b5528e523af571e5db1c721c479b6e
+
+[file_W75DM-fw]
+filename: W75DM-175.87.0.10.rom
+url: http://provd.wazo.community/firmwares/yealink/W75DM-175.87.0.10.rom
+size: 46633248
+sha1sum: 5161cfdcca6ad79622cad84ed636d9f62841b6ce
+
+[file_W90DM-fw]
+filename: W90DM-130.87.0.10.rom
+url: http://provd.wazo.community/firmwares/yealink/W90DM-130.87.0.10.rom
+size: 45686608
+sha1sum: 095c87b54d1dfc5018b36449bdb909ba268d5e84
 
 [file_W56H-fw]
-filename: W56H-61.85.0.20.rom
-url: http://provd.wazo.community/firmwares/yealink/W56H-61.85.0.20.rom
-size: 4412384
-sha1sum: 42b7b4dbfc98058635c6c5dc8bd8f88a4ade2568
+filename: W56H-61.87.0.5.rom
+url: http://provd.wazo.community/firmwares/yealink/W56H-61.87.0.5.rom
+size: 4648576
+sha1sum: 2fd48739316b125fc520cc3e3717b29bf589ab3e
+
+[file_W57R-fw]
+filename: W57R-118.87.0.5.rom
+url: http://provd.wazo.community/firmwares/yealink/W57R-118.87.0.5.rom
+size: 3233296
+sha1sum: fc5d4436c613dcdb346b8242f785d117f2605b01
 
 [file_W59R-fw]
-filename: W59R-115.85.0.20.rom
-url: http://provd.wazo.community/firmwares/yealink/W59R-115.85.0.20.rom
-size: 3148768
-sha1sum: 3e826495b1585156a300b1e3752013491791db2d
+filename: W59R-115.87.0.5.rom
+url: http://provd.wazo.community/firmwares/yealink/W59R-115.87.0.5.rom
+size: 3460048
+sha1sum: 0dd365779f8d62d13777103f3c4b61d454c1e682
+
+[file_W73H-fw]
+filename: W73H-116.87.0.5.rom
+url: http://provd.wazo.community/firmwares/yealink/W73H-116.87.0.5.rom
+size: 3228368
+sha1sum: e1f4c1a85e20316bbf4ec38c1420ff7cb302f863
+
+[file_W74H-fw]
+filename: W74H-119.87.0.5.rom
+url: http://provd.wazo.community/firmwares/yealink/W74H-119.87.0.5.rom
+size: 4763296
+sha1sum: 473596aca94c4375f6f24c601af4e689b848d8e2
+
+[file_W78H-fw]
+filename: W78H-16.87.0.5.rom
+url: http://provd.wazo.community/firmwares/yealink/W78H-16.87.0.5.rom
+size: 10806144
+sha1sum: 5b148616b5179479f6df90cdd151268046064bf8
 
 [file_T4S-ddphone-fw]
 filename: T4S-ddphone-66.85.0.56.rom

--- a/plugins/wazo_yealink/v87/plugin-info
+++ b/plugins/wazo_yealink/v87/plugin-info
@@ -1,7 +1,7 @@
 {
-    "version": "1.0.0",
-    "description": "Plugin for Yealink for AX83H & AX86R , T7X and T8X series in version 87.",
-    "description_fr": "Greffon pour Yealink pour les series AX83H & AX86R, T7X et T8X en version 87.",
+    "version": "1.1.0",
+    "description": "Plugin for Yealink for AX83H & AX86R, T7X, T8X, W70, W75, W80 and W90 series in version 87.",
+    "description_fr": "Greffon pour Yealink pour les series AX83H & AX86R, T7X, T8X, W70, W75, W80 and W90 en version 87.",
     "vendor" : "Yealink",
     "vendor.url" : "http://www.yealink.com",
     "vendor.description" : "Companies choose Yealink for that enable their geographically dispersed workforces to communicate and collaborate more effectively and productively over distances. Through the service provided by Yealink, people connect and collaborate from their desktops, meeting rooms, class rooms, and mobile setting.",
@@ -77,6 +77,67 @@
             "expansion_modules": 3,
             "switchboard": false,
             "type": "deskphone",
+            "protocol": "sip"
+        },
+        
+        "Yealink, W70B, 146.87.0.15": {
+            "lines": 10,
+            "high_availability": false,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": false,
+            "protocol": "sip"
+        },
+        "Yealink, W75B, 175.87.0.10": {
+            "lines": 20,
+            "high_availability": false,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": false,
+            "protocol": "sip"
+        },
+        "Yealink, W75DM, 175.87.0.10": {
+            "lines": 20,
+            "high_availability": false,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": false,
+            "protocol": "sip"
+        },
+        "Yealink, W80B, 103.87.0.10": {
+            "lines": 30,
+            "high_availability": false,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": false,
+            "protocol": "sip"
+        },
+        "Yealink, W80DM, 103.87.0.10": {
+            "lines": 30,
+            "high_availability": false,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": false,
+            "protocol": "sip"
+        },
+        "Yealink, W90, 130.87.0.10": {
+            "lines": 250,
+            "high_availability": false,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": true,
             "protocol": "sip"
         }
     }

--- a/plugins/wazo_yealink/v87/templates/W70B.tpl
+++ b/plugins/wazo_yealink/v87/templates/W70B.tpl
@@ -1,0 +1,141 @@
+#!version:1.0.0.1
+
+static.auto_provision.server.url = {{ XX_server_url }}/
+static.firmware.url = {{ XX_server_url }}/firmware/{{ XX_fw_filename }}
+
+{% if XX_handsets_fw -%}
+{% for handset, fw_file in XX_handsets_fw.items() -%}
+over_the_air.url.{{ handset }} = {{ XX_server_url }}/firmware/{{ fw_file }}
+{% endfor -%}
+over_the_air.handset_tip = 0
+{%- endif %}
+
+static.auto_provision.pnp_enable = 0
+static.auto_provision.custom.protect = 1
+static.auto_provision.handset_configured.enable = 1
+
+custom.handset.date_format = {{ XX_handset_lang|d('%NULL%') }}
+custom.handset.screen_saver.enable = 0
+custom.handset.silent_charging = 0
+
+sip.notify_reboot_enable = 0
+
+transfer.dsskey_deal_type = 1
+
+{% if vlan_enabled -%}
+static.network.vlan.internet_port_enable = 1
+static.network.vlan.internet_port_vid = {{ vlan_id }}
+static.network.vlan.internet_port_priority = {{ vlan_priority|d('%NULL%') }}
+{% else -%}
+static.network.vlan.internet_port_enable = 0
+static.network.vlan.internet_port_vid = %NULL%
+static.network.vlan.internet_port_priority = %NULL%
+{% endif %}
+
+{% if syslog_enabled -%}
+static.syslog.mode = 1
+static.syslog.server = {{ syslog_ip }}
+{% else -%}
+static.syslog.mode = 0
+static.syslog.server = %NULL%
+{% endif %}
+
+lang.wui = {{ XX_lang|d('%NULL%') }}
+custom.handset.language = {{ XX_handset_lang|d('%NULL%') }}
+
+voice.tone.country = {{ XX_country|d('%NULL%') }}
+
+local_time.ntp_server1 = {{ ntp_ip|d('pool.ntp.org') }}
+{% if XX_timezone -%}
+{{ XX_timezone }}
+{% else -%}
+local_time.time_zone = %NULL%
+local_time.time_zone_name = %NULL%
+local_time.summer_time = %NULL%
+{% endif %}
+
+{% if XX_xivo_phonebook_url -%}
+remote_phonebook.data.1.url = {{ XX_xivo_phonebook_url }}
+remote_phonebook.data.1.name = Wazo
+{% else -%}
+remote_phonebook.data.1.url = %NULL%
+remote_phonebook.data.1.name = %NULL%
+{% endif %}
+
+static.security.user_name.user = {{ user_username|d('user') }}
+static.security.user_name.admin = {{ admin_username|d('admin') }}
+static.security.user_password = {{ user_username|d('user') }}:{{ user_password|d('user') }}
+static.security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('admin') }}
+
+{% for template in XX_templates.values() -%}
+template.{{ template['id'] }}.name = Wazo{{ template['id'] }}
+template.{{ template['id'] }}.sip_server.1.address = {{ template['proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.1.port = {{ template['proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.1.transport_type = {{ XX_sip_transport }}
+{% if template['backup_proxy_ip'] -%}
+template.{{ template['id'] }}.sip_server.2.address = {{ template['backup_proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.2.port = {{ template['backup_proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.2.transport_type = {{ XX_sip_transport }}
+{% endif -%}
+{% endfor -%}
+
+{% for line_no, line in XX_sip_lines.items() -%}
+{% if line -%}
+account.{{ line_no }}.enable = 1
+account.{{ line_no }}.label = {{ line['number'] }} {{ line['display_name'] }}
+account.{{ line_no }}.display_name = {{ line['display_name'] }}
+account.{{ line_no }}.auth_name = {{ line['auth_username'] }}
+account.{{ line_no }}.user_name = {{ line['username'] }}
+account.{{ line_no }}.password = {{ line['password'] }}
+account.{{ line_no }}.sip_server.template = {{ line['XX_template_id'] }}
+account.{{ line_no }}.fallback.redundancy_type = 1
+account.{{ line_no }}.cid_source = 2
+account.{{ line_no }}.alert_info_url_enable = 0
+account.{{ line_no }}.nat.udp_update_enable = 1
+account.{{ line_no }}.dtmf.type = {{ line['XX_dtmf_type']|d('2') }}
+account.{{ line_no }}.dtmf.info_type = 1
+{% if XX_sip_transport == '2' and line['number'] != 'autoprov' -%}
+account.{{ line_no }}.srtp_encryption = 2
+{% else -%}
+account.{{ line_no }}.srtp_encryption = 0
+{% endif %}
+
+account.{{ line_no }}.codec.g722.enable = 1
+account.{{ line_no }}.codec.g722_1c_48kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_32kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_24kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1_24kpbs.enable = 1
+account.{{ line_no }}.codec.pcmu.enable = 1
+account.{{ line_no }}.codec.pcma.enable = 1
+account.{{ line_no }}.codec.g729.enable = 1
+account.{{ line_no }}.codec.g726_16.enable = 0
+account.{{ line_no }}.codec.g726_24.enable = 0
+account.{{ line_no }}.codec.g726_32.enable = 0
+account.{{ line_no }}.codec.g726_40.enable = 0
+account.{{ line_no }}.codec.g723_53.enable = 0
+account.{{ line_no }}.codec.g723_63.enable = 0
+account.{{ line_no }}.codec.opus.enable = 0
+account.{{ line_no }}.codec.ilbc.enable = 0
+
+{% if sip_subscribe_mwi -%}
+account.{{ line_no }}.subscribe_mwi = 1
+{% endif %}
+voice_mail.number.{{ line_no }} = {{ line['voicemail']|d('%NULL%') }}
+{% else -%}
+account.{{ line_no }}.enable = 0
+account.{{ line_no }}.label = %NULL%
+account.{{ line_no }}.display_name = %NULL%
+account.{{ line_no }}.auth_name = %NULL%
+account.{{ line_no }}.user_name = %NULL%
+account.{{ line_no }}.password = %NULL%
+account.{{ line_no }}.sip_server.template = %NULL%
+account.{{ line_no }}.subscribe_mwi = %NULL%
+voice_mail.number.{{ line_no }} = %NULL%
+{% endif %}
+{% endfor %}
+
+{% if XX_options['switchboard'] -%}
+call_waiting.enable = 0
+{% else -%}
+call_waiting.enable = 1
+{% endif %}

--- a/plugins/wazo_yealink/v87/templates/W75B.tpl
+++ b/plugins/wazo_yealink/v87/templates/W75B.tpl
@@ -1,0 +1,38 @@
+#!version:1.0.0.1
+
+static.auto_provision.server.url = {{ XX_server_url }}/
+static.firmware.url = {{ XX_server_url }}/firmware/{{ XX_fw_filename }}
+
+{% if XX_handsets_fw -%}
+{% for handset, fw_file in XX_handsets_fw.items() -%}
+over_the_air.url.{{ handset }} = {{ XX_server_url }}/firmware/{{ fw_file }}
+{% endfor -%}
+over_the_air.handset_tip = 0
+{%- endif %}
+
+sip.notify_reboot_enable = 0
+
+transfer.dsskey_deal_type = 1
+
+static.security.user_name.user = {{ user_username|d('user') }}
+static.security.user_name.admin = {{ admin_username|d('admin') }}
+static.security.user_password = {{ user_username|d('user') }}:{{ user_password|d('user') }}
+static.security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('admin') }}
+
+{% if vlan_enabled -%}
+static.network.vlan.internet_port_enable = 1
+static.network.vlan.internet_port_vid = {{ vlan_id }}
+static.network.vlan.internet_port_priority = {{ vlan_priority|d('%NULL%') }}
+{% else -%}
+static.network.vlan.internet_port_enable = 0
+static.network.vlan.internet_port_vid = %NULL%
+static.network.vlan.internet_port_priority = %NULL%
+{% endif %}
+
+{% if syslog_enabled -%}
+static.syslog.mode = 1
+static.syslog.server = {{ syslog_ip }}
+{% else -%}
+static.syslog.mode = 0
+static.syslog.server = %NULL%
+{% endif %}

--- a/plugins/wazo_yealink/v87/templates/W75DM.tpl
+++ b/plugins/wazo_yealink/v87/templates/W75DM.tpl
@@ -1,0 +1,141 @@
+#!version:1.0.0.1
+
+static.auto_provision.server.url = {{ XX_server_url }}/
+static.firmware.url = {{ XX_server_url }}/firmware/{{ XX_fw_filename }}
+
+{% if XX_handsets_fw -%}
+{% for handset, fw_file in XX_handsets_fw.items() -%}
+over_the_air.url.{{ handset }} = {{ XX_server_url }}/firmware/{{ fw_file }}
+{% endfor -%}
+over_the_air.handset_tip = 0
+{%- endif %}
+
+static.auto_provision.pnp_enable = 0
+static.auto_provision.custom.protect = 1
+static.auto_provision.handset_configured.enable = 1
+
+custom.handset.date_format = {{ XX_handset_lang|d('%NULL%') }}
+custom.handset.screen_saver.enable = 0
+custom.handset.silent_charging = 0
+
+sip.notify_reboot_enable = 0
+
+transfer.dsskey_deal_type = 1
+
+{% if vlan_enabled -%}
+static.network.vlan.internet_port_enable = 1
+static.network.vlan.internet_port_vid = {{ vlan_id }}
+static.network.vlan.internet_port_priority = {{ vlan_priority|d('%NULL%') }}
+{% else -%}
+static.network.vlan.internet_port_enable = 0
+static.network.vlan.internet_port_vid = %NULL%
+static.network.vlan.internet_port_priority = %NULL%
+{% endif %}
+
+{% if syslog_enabled -%}
+static.syslog.mode = 1
+static.syslog.server = {{ syslog_ip }}
+{% else -%}
+static.syslog.mode = 0
+static.syslog.server = %NULL%
+{% endif %}
+
+lang.wui = {{ XX_lang|d('%NULL%') }}
+custom.handset.language = {{ XX_handset_lang|d('%NULL%') }}
+
+voice.tone.country = {{ XX_country|d('%NULL%') }}
+
+local_time.ntp_server1 = {{ ntp_ip|d('pool.ntp.org') }}
+{% if XX_timezone -%}
+{{ XX_timezone }}
+{% else -%}
+local_time.time_zone = %NULL%
+local_time.time_zone_name = %NULL%
+local_time.summer_time = %NULL%
+{% endif %}
+
+{% if XX_xivo_phonebook_url -%}
+remote_phonebook.data.1.url = {{ XX_xivo_phonebook_url }}
+remote_phonebook.data.1.name = Wazo
+{% else -%}
+remote_phonebook.data.1.url = %NULL%
+remote_phonebook.data.1.name = %NULL%
+{% endif %}
+
+static.security.user_name.user = {{ user_username|d('user') }}
+static.security.user_name.admin = {{ admin_username|d('admin') }}
+static.security.user_password = {{ user_username|d('user') }}:{{ user_password|d('user') }}
+static.security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('admin') }}
+
+{% for template in XX_templates.values() -%}
+template.{{ template['id'] }}.name = Wazo{{ template['id'] }}
+template.{{ template['id'] }}.sip_server.1.address = {{ template['proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.1.port = {{ template['proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.1.transport_type = {{ XX_sip_transport }}
+{% if template['backup_proxy_ip'] -%}
+template.{{ template['id'] }}.sip_server.2.address = {{ template['backup_proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.2.port = {{ template['backup_proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.2.transport_type = {{ XX_sip_transport }}
+{% endif -%}
+{% endfor -%}
+
+{% for line_no, line in XX_sip_lines.items() -%}
+{% if line -%}
+account.{{ line_no }}.enable = 1
+account.{{ line_no }}.label = {{ line['number'] }} {{ line['display_name'] }}
+account.{{ line_no }}.display_name = {{ line['display_name'] }}
+account.{{ line_no }}.auth_name = {{ line['auth_username'] }}
+account.{{ line_no }}.user_name = {{ line['username'] }}
+account.{{ line_no }}.password = {{ line['password'] }}
+account.{{ line_no }}.sip_server.template = {{ line['XX_template_id'] }}
+account.{{ line_no }}.fallback.redundancy_type = 1
+account.{{ line_no }}.cid_source = 2
+account.{{ line_no }}.alert_info_url_enable = 0
+account.{{ line_no }}.nat.udp_update_enable = 1
+account.{{ line_no }}.dtmf.type = {{ line['XX_dtmf_type']|d('2') }}
+account.{{ line_no }}.dtmf.info_type = 1
+{% if XX_sip_transport == '2' and line['number'] != 'autoprov' -%}
+account.{{ line_no }}.srtp_encryption = 2
+{% else -%}
+account.{{ line_no }}.srtp_encryption = 0
+{% endif %}
+
+account.{{ line_no }}.codec.g722.enable = 1
+account.{{ line_no }}.codec.g722_1c_48kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_32kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_24kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1_24kpbs.enable = 1
+account.{{ line_no }}.codec.pcmu.enable = 1
+account.{{ line_no }}.codec.pcma.enable = 1
+account.{{ line_no }}.codec.g729.enable = 1
+account.{{ line_no }}.codec.g726_16.enable = 0
+account.{{ line_no }}.codec.g726_24.enable = 0
+account.{{ line_no }}.codec.g726_32.enable = 0
+account.{{ line_no }}.codec.g726_40.enable = 0
+account.{{ line_no }}.codec.g723_53.enable = 0
+account.{{ line_no }}.codec.g723_63.enable = 0
+account.{{ line_no }}.codec.opus.enable = 0
+account.{{ line_no }}.codec.ilbc.enable = 0
+
+{% if sip_subscribe_mwi -%}
+account.{{ line_no }}.subscribe_mwi = 1
+{% endif %}
+voice_mail.number.{{ line_no }} = {{ line['voicemail']|d('%NULL%') }}
+{% else -%}
+account.{{ line_no }}.enable = 0
+account.{{ line_no }}.label = %NULL%
+account.{{ line_no }}.display_name = %NULL%
+account.{{ line_no }}.auth_name = %NULL%
+account.{{ line_no }}.user_name = %NULL%
+account.{{ line_no }}.password = %NULL%
+account.{{ line_no }}.sip_server.template = %NULL%
+account.{{ line_no }}.subscribe_mwi = %NULL%
+voice_mail.number.{{ line_no }} = %NULL%
+{% endif %}
+{% endfor %}
+
+{% if XX_options['switchboard'] -%}
+call_waiting.enable = 0
+{% else -%}
+call_waiting.enable = 1
+{% endif %}

--- a/plugins/wazo_yealink/v87/templates/W80B.tpl
+++ b/plugins/wazo_yealink/v87/templates/W80B.tpl
@@ -1,0 +1,38 @@
+#!version:1.0.0.1
+
+static.auto_provision.server.url = {{ XX_server_url }}/
+static.firmware.url = {{ XX_server_url }}/firmware/{{ XX_fw_filename }}
+
+{% if XX_handsets_fw -%}
+{% for handset, fw_file in XX_handsets_fw.items() -%}
+over_the_air.url.{{ handset }} = {{ XX_server_url }}/firmware/{{ fw_file }}
+{% endfor -%}
+over_the_air.handset_tip = 0
+{%- endif %}
+
+sip.notify_reboot_enable = 0
+
+transfer.dsskey_deal_type = 1
+
+static.security.user_name.user = {{ user_username|d('user') }}
+static.security.user_name.admin = {{ admin_username|d('admin') }}
+static.security.user_password = {{ user_username|d('user') }}:{{ user_password|d('user') }}
+static.security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('admin') }}
+
+{% if vlan_enabled -%}
+static.network.vlan.internet_port_enable = 1
+static.network.vlan.internet_port_vid = {{ vlan_id }}
+static.network.vlan.internet_port_priority = {{ vlan_priority|d('%NULL%') }}
+{% else -%}
+static.network.vlan.internet_port_enable = 0
+static.network.vlan.internet_port_vid = %NULL%
+static.network.vlan.internet_port_priority = %NULL%
+{% endif %}
+
+{% if syslog_enabled -%}
+static.syslog.mode = 1
+static.syslog.server = {{ syslog_ip }}
+{% else -%}
+static.syslog.mode = 0
+static.syslog.server = %NULL%
+{% endif %}

--- a/plugins/wazo_yealink/v87/templates/W80DM.tpl
+++ b/plugins/wazo_yealink/v87/templates/W80DM.tpl
@@ -1,0 +1,141 @@
+#!version:1.0.0.1
+
+static.auto_provision.server.url = {{ XX_server_url }}/
+static.firmware.url = {{ XX_server_url }}/firmware/{{ XX_fw_filename }}
+
+{% if XX_handsets_fw -%}
+{% for handset, fw_file in XX_handsets_fw.items() -%}
+over_the_air.url.{{ handset }} = {{ XX_server_url }}/firmware/{{ fw_file }}
+{% endfor -%}
+over_the_air.handset_tip = 0
+{%- endif %}
+
+static.auto_provision.pnp_enable = 0
+static.auto_provision.custom.protect = 1
+static.auto_provision.handset_configured.enable = 1
+
+custom.handset.date_format = {{ XX_handset_lang|d('%NULL%') }}
+custom.handset.screen_saver.enable = 0
+custom.handset.silent_charging = 0
+
+sip.notify_reboot_enable = 0
+
+transfer.dsskey_deal_type = 1
+
+{% if vlan_enabled -%}
+static.network.vlan.internet_port_enable = 1
+static.network.vlan.internet_port_vid = {{ vlan_id }}
+static.network.vlan.internet_port_priority = {{ vlan_priority|d('%NULL%') }}
+{% else -%}
+static.network.vlan.internet_port_enable = 0
+static.network.vlan.internet_port_vid = %NULL%
+static.network.vlan.internet_port_priority = %NULL%
+{% endif %}
+
+{% if syslog_enabled -%}
+static.syslog.mode = 1
+static.syslog.server = {{ syslog_ip }}
+{% else -%}
+static.syslog.mode = 0
+static.syslog.server = %NULL%
+{% endif %}
+
+lang.wui = {{ XX_lang|d('%NULL%') }}
+custom.handset.language = {{ XX_handset_lang|d('%NULL%') }}
+
+voice.tone.country = {{ XX_country|d('%NULL%') }}
+
+local_time.ntp_server1 = {{ ntp_ip|d('pool.ntp.org') }}
+{% if XX_timezone -%}
+{{ XX_timezone }}
+{% else -%}
+local_time.time_zone = %NULL%
+local_time.time_zone_name = %NULL%
+local_time.summer_time = %NULL%
+{% endif %}
+
+{% if XX_xivo_phonebook_url -%}
+remote_phonebook.data.1.url = {{ XX_xivo_phonebook_url }}
+remote_phonebook.data.1.name = Wazo
+{% else -%}
+remote_phonebook.data.1.url = %NULL%
+remote_phonebook.data.1.name = %NULL%
+{% endif %}
+
+static.security.user_name.user = {{ user_username|d('user') }}
+static.security.user_name.admin = {{ admin_username|d('admin') }}
+static.security.user_password = {{ user_username|d('user') }}:{{ user_password|d('user') }}
+static.security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('admin') }}
+
+{% for template in XX_templates.values() -%}
+template.{{ template['id'] }}.name = Wazo{{ template['id'] }}
+template.{{ template['id'] }}.sip_server.1.address = {{ template['proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.1.port = {{ template['proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.1.transport_type = {{ XX_sip_transport }}
+{% if template['backup_proxy_ip'] -%}
+template.{{ template['id'] }}.sip_server.2.address = {{ template['backup_proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.2.port = {{ template['backup_proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.2.transport_type = {{ XX_sip_transport }}
+{% endif -%}
+{% endfor -%}
+
+{% for line_no, line in XX_sip_lines.items() -%}
+{% if line -%}
+account.{{ line_no }}.enable = 1
+account.{{ line_no }}.label = {{ line['number'] }} {{ line['display_name'] }}
+account.{{ line_no }}.display_name = {{ line['display_name'] }}
+account.{{ line_no }}.auth_name = {{ line['auth_username'] }}
+account.{{ line_no }}.user_name = {{ line['username'] }}
+account.{{ line_no }}.password = {{ line['password'] }}
+account.{{ line_no }}.sip_server.template = {{ line['XX_template_id'] }}
+account.{{ line_no }}.fallback.redundancy_type = 1
+account.{{ line_no }}.cid_source = 2
+account.{{ line_no }}.alert_info_url_enable = 0
+account.{{ line_no }}.nat.udp_update_enable = 1
+account.{{ line_no }}.dtmf.type = {{ line['XX_dtmf_type']|d('2') }}
+account.{{ line_no }}.dtmf.info_type = 1
+{% if XX_sip_transport == '2' and line['number'] != 'autoprov' -%}
+account.{{ line_no }}.srtp_encryption = 2
+{% else -%}
+account.{{ line_no }}.srtp_encryption = 0
+{% endif %}
+
+account.{{ line_no }}.codec.g722.enable = 1
+account.{{ line_no }}.codec.g722_1c_48kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_32kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_24kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1_24kpbs.enable = 1
+account.{{ line_no }}.codec.pcmu.enable = 1
+account.{{ line_no }}.codec.pcma.enable = 1
+account.{{ line_no }}.codec.g729.enable = 1
+account.{{ line_no }}.codec.g726_16.enable = 0
+account.{{ line_no }}.codec.g726_24.enable = 0
+account.{{ line_no }}.codec.g726_32.enable = 0
+account.{{ line_no }}.codec.g726_40.enable = 0
+account.{{ line_no }}.codec.g723_53.enable = 0
+account.{{ line_no }}.codec.g723_63.enable = 0
+account.{{ line_no }}.codec.opus.enable = 0
+account.{{ line_no }}.codec.ilbc.enable = 0
+
+{% if sip_subscribe_mwi -%}
+account.{{ line_no }}.subscribe_mwi = 1
+{% endif %}
+voice_mail.number.{{ line_no }} = {{ line['voicemail']|d('%NULL%') }}
+{% else -%}
+account.{{ line_no }}.enable = 0
+account.{{ line_no }}.label = %NULL%
+account.{{ line_no }}.display_name = %NULL%
+account.{{ line_no }}.auth_name = %NULL%
+account.{{ line_no }}.user_name = %NULL%
+account.{{ line_no }}.password = %NULL%
+account.{{ line_no }}.sip_server.template = %NULL%
+account.{{ line_no }}.subscribe_mwi = %NULL%
+voice_mail.number.{{ line_no }} = %NULL%
+{% endif %}
+{% endfor %}
+
+{% if XX_options['switchboard'] -%}
+call_waiting.enable = 0
+{% else -%}
+call_waiting.enable = 1
+{% endif %}

--- a/plugins/wazo_yealink/v87/templates/W90B.tpl
+++ b/plugins/wazo_yealink/v87/templates/W90B.tpl
@@ -1,0 +1,38 @@
+#!version:1.0.0.1
+
+static.auto_provision.server.url = {{ XX_server_url }}/
+static.firmware.url = {{ XX_server_url }}/firmware/{{ XX_fw_filename }}
+
+{% if XX_handsets_fw -%}
+{% for handset, fw_file in XX_handsets_fw.items() -%}
+over_the_air.url.{{ handset }} = {{ XX_server_url }}/firmware/{{ fw_file }}
+{% endfor -%}
+over_the_air.handset_tip = 0
+{%- endif %}
+
+sip.notify_reboot_enable = 0
+
+transfer.dsskey_deal_type = 1
+
+static.security.user_name.user = {{ user_username|d('user') }}
+static.security.user_name.admin = {{ admin_username|d('admin') }}
+static.security.user_password = {{ user_username|d('user') }}:{{ user_password|d('user') }}
+static.security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('admin') }}
+
+{% if vlan_enabled -%}
+static.network.vlan.internet_port_enable = 1
+static.network.vlan.internet_port_vid = {{ vlan_id }}
+static.network.vlan.internet_port_priority = {{ vlan_priority|d('%NULL%') }}
+{% else -%}
+static.network.vlan.internet_port_enable = 0
+static.network.vlan.internet_port_vid = %NULL%
+static.network.vlan.internet_port_priority = %NULL%
+{% endif %}
+
+{% if syslog_enabled -%}
+static.syslog.mode = 1
+static.syslog.server = {{ syslog_ip }}
+{% else -%}
+static.syslog.mode = 0
+static.syslog.server = %NULL%
+{% endif %}

--- a/plugins/wazo_yealink/v87/templates/W90DM.tpl
+++ b/plugins/wazo_yealink/v87/templates/W90DM.tpl
@@ -1,0 +1,141 @@
+#!version:1.0.0.1
+
+static.auto_provision.server.url = {{ XX_server_url }}/
+static.firmware.url = {{ XX_server_url }}/firmware/{{ XX_fw_filename }}
+
+{% if XX_handsets_fw -%}
+{% for handset, fw_file in XX_handsets_fw.items() -%}
+over_the_air.url.{{ handset }} = {{ XX_server_url }}/firmware/{{ fw_file }}
+{% endfor -%}
+over_the_air.handset_tip = 0
+{%- endif %}
+
+static.auto_provision.pnp_enable = 0
+static.auto_provision.custom.protect = 1
+static.auto_provision.handset_configured.enable = 1
+
+custom.handset.date_format = {{ XX_handset_lang|d('%NULL%') }}
+custom.handset.screen_saver.enable = 0
+custom.handset.silent_charging = 0
+
+sip.notify_reboot_enable = 0
+
+transfer.dsskey_deal_type = 1
+
+{% if vlan_enabled -%}
+static.network.vlan.internet_port_enable = 1
+static.network.vlan.internet_port_vid = {{ vlan_id }}
+static.network.vlan.internet_port_priority = {{ vlan_priority|d('%NULL%') }}
+{% else -%}
+static.network.vlan.internet_port_enable = 0
+static.network.vlan.internet_port_vid = %NULL%
+static.network.vlan.internet_port_priority = %NULL%
+{% endif %}
+
+{% if syslog_enabled -%}
+static.syslog.mode = 1
+static.syslog.server = {{ syslog_ip }}
+{% else -%}
+static.syslog.mode = 0
+static.syslog.server = %NULL%
+{% endif %}
+
+lang.wui = {{ XX_lang|d('%NULL%') }}
+custom.handset.language = {{ XX_handset_lang|d('%NULL%') }}
+
+voice.tone.country = {{ XX_country|d('%NULL%') }}
+
+local_time.ntp_server1 = {{ ntp_ip|d('pool.ntp.org') }}
+{% if XX_timezone -%}
+{{ XX_timezone }}
+{% else -%}
+local_time.time_zone = %NULL%
+local_time.time_zone_name = %NULL%
+local_time.summer_time = %NULL%
+{% endif %}
+
+{% if XX_xivo_phonebook_url -%}
+remote_phonebook.data.1.url = {{ XX_xivo_phonebook_url }}
+remote_phonebook.data.1.name = Wazo
+{% else -%}
+remote_phonebook.data.1.url = %NULL%
+remote_phonebook.data.1.name = %NULL%
+{% endif %}
+
+static.security.user_name.user = {{ user_username|d('user') }}
+static.security.user_name.admin = {{ admin_username|d('admin') }}
+static.security.user_password = {{ user_username|d('user') }}:{{ user_password|d('user') }}
+static.security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('admin') }}
+
+{% for template in XX_templates.values() -%}
+template.{{ template['id'] }}.name = Wazo{{ template['id'] }}
+template.{{ template['id'] }}.sip_server.1.address = {{ template['proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.1.port = {{ template['proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.1.transport_type = {{ XX_sip_transport }}
+{% if template['backup_proxy_ip'] -%}
+template.{{ template['id'] }}.sip_server.2.address = {{ template['backup_proxy_ip'] }}
+template.{{ template['id'] }}.sip_server.2.port = {{ template['backup_proxy_port']|d('%NULL%') }}
+template.{{ template['id'] }}.sip_server.2.transport_type = {{ XX_sip_transport }}
+{% endif -%}
+{% endfor -%}
+
+{% for line_no, line in XX_sip_lines.items() -%}
+{% if line -%}
+account.{{ line_no }}.enable = 1
+account.{{ line_no }}.label = {{ line['number'] }} {{ line['display_name'] }}
+account.{{ line_no }}.display_name = {{ line['display_name'] }}
+account.{{ line_no }}.auth_name = {{ line['auth_username'] }}
+account.{{ line_no }}.user_name = {{ line['username'] }}
+account.{{ line_no }}.password = {{ line['password'] }}
+account.{{ line_no }}.sip_server.template = {{ line['XX_template_id'] }}
+account.{{ line_no }}.fallback.redundancy_type = 1
+account.{{ line_no }}.cid_source = 2
+account.{{ line_no }}.alert_info_url_enable = 0
+account.{{ line_no }}.nat.udp_update_enable = 1
+account.{{ line_no }}.dtmf.type = {{ line['XX_dtmf_type']|d('2') }}
+account.{{ line_no }}.dtmf.info_type = 1
+{% if XX_sip_transport == '2' and line['number'] != 'autoprov' -%}
+account.{{ line_no }}.srtp_encryption = 2
+{% else -%}
+account.{{ line_no }}.srtp_encryption = 0
+{% endif %}
+
+account.{{ line_no }}.codec.g722.enable = 1
+account.{{ line_no }}.codec.g722_1c_48kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_32kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1c_24kpbs.enable = 1
+account.{{ line_no }}.codec.g722_1_24kpbs.enable = 1
+account.{{ line_no }}.codec.pcmu.enable = 1
+account.{{ line_no }}.codec.pcma.enable = 1
+account.{{ line_no }}.codec.g729.enable = 1
+account.{{ line_no }}.codec.g726_16.enable = 0
+account.{{ line_no }}.codec.g726_24.enable = 0
+account.{{ line_no }}.codec.g726_32.enable = 0
+account.{{ line_no }}.codec.g726_40.enable = 0
+account.{{ line_no }}.codec.g723_53.enable = 0
+account.{{ line_no }}.codec.g723_63.enable = 0
+account.{{ line_no }}.codec.opus.enable = 0
+account.{{ line_no }}.codec.ilbc.enable = 0
+
+{% if sip_subscribe_mwi -%}
+account.{{ line_no }}.subscribe_mwi = 1
+{% endif %}
+voice_mail.number.{{ line_no }} = {{ line['voicemail']|d('%NULL%') }}
+{% else -%}
+account.{{ line_no }}.enable = 0
+account.{{ line_no }}.label = %NULL%
+account.{{ line_no }}.display_name = %NULL%
+account.{{ line_no }}.auth_name = %NULL%
+account.{{ line_no }}.user_name = %NULL%
+account.{{ line_no }}.password = %NULL%
+account.{{ line_no }}.sip_server.template = %NULL%
+account.{{ line_no }}.subscribe_mwi = %NULL%
+voice_mail.number.{{ line_no }} = %NULL%
+{% endif %}
+{% endfor %}
+
+{% if XX_options['switchboard'] -%}
+call_waiting.enable = 0
+{% else -%}
+call_waiting.enable = 1
+{% endif %}


### PR DESCRIPTION
Hello there,

Update for Yealink v87 plugin to support DECT Base W70B/W75B/W80B/W90B.

Firmwares are available on Yealink support website or below :

https://dl.acrib.fr/wazo/W70B-146.87.0.15.rom
https://dl.acrib.fr/wazo/W80B-103.87.0.10.rom
https://dl.acrib.fr/wazo/W80DM-103.87.0.10.rom
https://dl.acrib.fr/wazo/W75DM-175.87.0.10.rom
https://dl.acrib.fr/wazo/W90DM-130.87.0.10.rom
https://dl.acrib.fr/wazo/W56H-61.87.0.5.rom
https://dl.acrib.fr/wazo/W57R-118.87.0.5.rom
https://dl.acrib.fr/wazo/W59R-115.87.0.5.rom
https://dl.acrib.fr/wazo/W73H-116.87.0.5.rom
https://dl.acrib.fr/wazo/W74H-119.87.0.5.rom
https://dl.acrib.fr/wazo/W78H-16.87.0.5.rom

Thank you :)
