### PR TITLE
grandstream: add plugin for GXP16XX in version 1.0.7.81

### DIFF
--- a/plugins/wazo_grandstream/build.py
+++ b/plugins/wazo_grandstream/build.py
@@ -1,5 +1,5 @@
 """
-Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 SPDX-License-Identifier: GPL-3.0-or-later
 
 Depends on the following external programs:
@@ -106,6 +106,23 @@ def build_1_0_7_13(path: str) -> None:
         ]
     )
     check_call(['rsync', '-rlp', '--exclude', '.*', 'v1_0_7_13/', path])
+
+
+@target('1.0.7.81', 'wazo-grandstream-1.0.7.81')
+def build_1_0_7_81(path: str) -> None:
+    check_call(
+        [
+            'rsync',
+            '-rlp',
+            '--exclude',
+            '.*',
+            '--include',
+            '/templates/*',
+            'common/',
+            path,
+        ]
+    )
+    check_call(['rsync', '-rlp', '--exclude', '.*', 'v1_0_7_81/', path])
 
 
 @target('1.0.8.6', 'wazo-grandstream-1.0.8.6')

--- a/plugins/wazo_grandstream/v1_0_7_81/entry.py
+++ b/plugins/wazo_grandstream/v1_0_7_81/entry.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import TypedDict
+
+    from ..common.common import (  # noqa: F401
+        BaseGrandstreamPgAssociator,
+        BaseGrandstreamPlugin,
+    )
+
+    class CommonGlobalsDict(TypedDict):
+        BaseGrandstreamPlugin: type[BaseGrandstreamPlugin]
+        BaseGrandstreamPgAssociator: type[BaseGrandstreamPgAssociator]
+
+
+common: CommonGlobalsDict = {}  # type: ignore[typeddict-item]
+execfile_('common.py', common)  # type: ignore[name-defined]
+
+MODELS = [
+    'GXP1610',
+    'GXP1615',
+    'GXP1620',
+    'GXP1625',
+    'GXP1628',
+    'GXP1630',
+]
+VERSION = '1.0.7.81'
+
+
+class GrandstreamPlugin(common['BaseGrandstreamPlugin']):  # type: ignore[valid-type,misc]
+    IS_PLUGIN = True
+
+    _MODELS = MODELS
+
+    pg_associator = common['BaseGrandstreamPgAssociator'](MODELS, VERSION)

--- a/plugins/wazo_grandstream/v1_0_7_81/install.md
+++ b/plugins/wazo_grandstream/v1_0_7_81/install.md
@@ -1,0 +1,5 @@
+# Installation
+
+If you are using this phone series through Internet and have to provide the provisioning URL
+manually, you may have to add the `/Grandstream` suffix to the URL. Some phones add it
+automatically and some don't.

--- a/plugins/wazo_grandstream/v1_0_7_81/limitations.md
+++ b/plugins/wazo_grandstream/v1_0_7_81/limitations.md
@@ -1,0 +1,4 @@
+# Limitations
+
+* **Phonebook**: it is not possible to use the Wazo phonebook using the GXP16xx phones, due to a
+  lack of features in the XML Application.

--- a/plugins/wazo_grandstream/v1_0_7_81/pkgs/pkgs.db
+++ b/plugins/wazo_grandstream/v1_0_7_81/pkgs/pkgs.db
@@ -1,0 +1,15 @@
+[pkg_GXP1600-fw]
+description: Firmware for Grandstream GXP16XX
+description_fr: Micrologiciel pour Grandstream GXP16XX
+version: 1.0.7.81
+files: GXP16XX-fw
+install: grandstream-fw
+
+[install_grandstream-fw]
+a-b: unzip $FILE1
+b-c: cp */*/*.bin ./
+
+[file_GXP16XX-fw]
+url: https://firmware.grandstream.com/Release_GXP16xx_1.0.7.81.zip
+size: 13752026
+sha1sum: e1935a34ad467a6db97cc18c28696d6fc2ba02c3

--- a/plugins/wazo_grandstream/v1_0_7_81/plugin-info
+++ b/plugins/wazo_grandstream/v1_0_7_81/plugin-info
@@ -1,0 +1,65 @@
+{
+    "version": "0.1.1",
+    "description": "Plugin for Grandstream GXP1610, GXP1615, GXP1620, GXP1625, GXP1628 and GXP1630 in version 1.0.7.81.",
+    "description_fr": "Greffon pour Grandstream GXP1610, GXP1615, GXP1620, GXP1625, GXP1628 and GXP1630 en version 1.0.7.81.",
+    "vendor" : "Grandstream",
+    "vendor.url" : "http://www.grandstream.com",
+    "vendor.description" : "Grandstream Networks, Inc. is an award-winning designer and ISO 9001 certified manufacturer of next generation IP voice & video products for broadband networks. Grandstream’s products deliver superb sound and picture quality, rich telephony features, full compliance with industry standards, and broad interoperability with most service providers and 3rd party SIP based VoIP products.",
+    "vendor.official" : 0,
+    "capabilities": {
+        "Grandstream, GXP1610, 1.0.7.81": {
+            "lines": 1,
+            "high_availability": true,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Grandstream, GXP1615, 1.0.7.81": {
+            "lines": 1,
+            "high_availability": true,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Grandstream, GXP1620, 1.0.7.81": {
+            "lines": 2,
+            "high_availability": true,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Grandstream, GXP1625, 1.0.7.81": {
+            "lines": 2,
+            "high_availability": true,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Grandstream, GXP1628, 1.0.7.81": {
+            "lines": 2,
+            "high_availability": true,
+            "function_keys": 8,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        },
+        "Grandstream, GXP1630, 1.0.7.81": {
+            "lines": 3,
+            "high_availability": true,
+            "function_keys": 8,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "deskphone",
+            "protocol": "sip"
+        }
+    }
+}


### PR DESCRIPTION
Why: fixes important security vulnerability. CVE-2026-2329

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a new versioned plugin bundle and a build target; risk is mainly around packaging/build output correctness and firmware download metadata.
> 
> **Overview**
> Adds a new Grandstream GXP16xx plugin bundle for firmware `1.0.7.81`, including `entry.py`, metadata (`plugin-info` capabilities), firmware package definition (`pkgs.db`), and accompanying `install.md`/`limitations.md` docs.
> 
> Updates `plugins/wazo_grandstream/build.py` to register a new `@target('1.0.7.81', ...)` build that rsyncs `common/` plus the new `v1_0_7_81/` directory, and bumps the build script copyright year to 2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c76576b835bff8b28dc79e0d2b9782278bed617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->