### PR TITLE
🚀 YEALINK | New firmwares series

### DIFF
--- a/plugins/wazo_yealink/v87/entry.py
+++ b/plugins/wazo_yealink/v87/entry.py
@@ -49,32 +49,32 @@ MODEL_INFO = {
         'firmware': 'T58W-OS12-150.87.0.15.rom',
     },
     'T73U': {
-        'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
+        'version': '185.87.0.34',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom',
     },
     'T73W': {
-        'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
+        'version': '185.87.0.34',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom',
     },
     'T74U': {
-        'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
+        'version': '185.87.0.34',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom',
     },
     'T74W': {
-        'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
+        'version': '185.87.0.34',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom',
     },
     'T77U': {
-        'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
+        'version': '185.87.0.34',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom',
     },
     'T85W': {
-        'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
+        'version': '185.87.0.34',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom',
     },
     'T87W': {
-        'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
+        'version': '185.87.0.34',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom',
     },
     'T88W': {
         'version': '192.87.0.10',

--- a/plugins/wazo_yealink/v87/entry.py
+++ b/plugins/wazo_yealink/v87/entry.py
@@ -85,12 +85,12 @@ MODEL_INFO = {
         'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
     },
     'AX83H': {
-        'version': '180.87.0.5',
-        'firmware': 'AX83(AX83,AX86)-180.87.0.5.rom',
+        'version': '180.87.0.15',
+        'firmware': 'AX83(AX83,AX86)-180.87.0.15.rom',
     },
     'AX86R': {
-        'version': '180.87.0.5',
-        'firmware': 'AX83(AX83,AX86)-180.87.0.5.rom',
+        'version': '180.87.0.15',
+        'firmware': 'AX83(AX83,AX86)-180.87.0.15.rom',
     },
     'W70B': {
         'version': '146.87.0.15',

--- a/plugins/wazo_yealink/v87/entry.py
+++ b/plugins/wazo_yealink/v87/entry.py
@@ -58,23 +58,23 @@ MODEL_INFO = {
     },
     'T74U': {
         'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T74W': {
         'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T77U': {
         'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T85W': {
         'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T87W': {
         'version': '185.87.0.33',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T88W': {
         'version': '192.87.0.10',
@@ -99,22 +99,22 @@ MODEL_INFO = {
     },
     'W75DM': {
         'version': '175.87.0.18',
-        'firmware': 'W75DM-175.87.0.18.rom',
+        'firmware': '$PN-175.87.0.18.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W75B': {
-        'version': '175.87.0.10',
-        'firmware': 'W75DM-175.87.0.10.rom',  # Yealink Inject W75B fw inside W75DM
+        'version': '175.87.0.18',
+        'firmware': '$PN-175.87.0.18.rom',  # Yealink Inject W75B fw inside W75DM
         'handsets_fw': HANDSETS_FW,
     },
     'W80DM': {
         'version': '103.87.0.18',
-        'firmware': 'W80DM-103.87.0.18.rom',
+        'firmware': '$PN-103.87.0.18.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W80B': {
-        'version': '103.87.0.10',
-        'firmware': '$PN-103.87.0.10.rom',
+        'version': '103.87.0.18',
+        'firmware': '$PN-103.87.0.18.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W90DM': {
@@ -123,8 +123,8 @@ MODEL_INFO = {
         'handsets_fw': HANDSETS_FW,
     },
     'W90B': {
-        'version': '130.87.0.10',
-        'firmware': '$PN-130.87.0.10.rom',  # $PN = Product Name, i.e W90B
+        'version': '130.87.0.18',
+        'firmware': '$PN-130.87.0.18.rom',  # $PN = Product Name, i.e W90B
         'handsets_fw': HANDSETS_FW,
     },
 }

--- a/plugins/wazo_yealink/v87/entry.py
+++ b/plugins/wazo_yealink/v87/entry.py
@@ -49,40 +49,40 @@ MODEL_INFO = {
         'firmware': 'T58W-OS12-150.87.0.15.rom',
     },
     'T73U': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '185.87.0.33',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T73W': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '185.87.0.33',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T74U': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '185.87.0.33',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T74W': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '185.87.0.33',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T77U': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '185.87.0.33',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T85W': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '185.87.0.33',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T87W': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '185.87.0.33',
+        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.33.rom',
     },
     'T88W': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '192.87.0.10',
+        'firmware': 'T88(T88W,T88V)-192.87.0.10.rom',
     },
     'T88V': {
-        'version': '185.87.0.10',
-        'firmware': 'T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom',
+        'version': '192.87.0.10',
+        'firmware': 'T88(T88W,T88V)-192.87.0.10.rom',
     },
     'AX83H': {
         'version': '180.87.0.15',
@@ -93,13 +93,13 @@ MODEL_INFO = {
         'firmware': 'AX83(AX83,AX86)-180.87.0.15.rom',
     },
     'W70B': {
-        'version': '146.87.0.15',
-        'firmware': 'W70B-146.87.0.15.rom',
+        'version': '146.87.0.21',
+        'firmware': 'W70B-146.87.0.21.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W75DM': {
-        'version': '175.87.0.10',
-        'firmware': 'W75DM-175.87.0.10.rom',
+        'version': '175.87.0.18',
+        'firmware': 'W75DM-175.87.0.18.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W75B': {
@@ -108,8 +108,8 @@ MODEL_INFO = {
         'handsets_fw': HANDSETS_FW,
     },
     'W80DM': {
-        'version': '103.87.0.10',
-        'firmware': '$PN-103.87.0.10.rom',
+        'version': '103.87.0.18',
+        'firmware': 'W80DM-103.87.0.18.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W80B': {
@@ -118,8 +118,8 @@ MODEL_INFO = {
         'handsets_fw': HANDSETS_FW,
     },
     'W90DM': {
-        'version': '130.87.0.10',
-        'firmware': '$PN-130.87.0.10.rom',  # $PN = Product Name, i.e W90DM
+        'version': '130.87.0.18',
+        'firmware': '$PN-130.87.0.18.rom',  # $PN = Product Name, i.e W90DM
         'handsets_fw': HANDSETS_FW,
     },
     'W90B': {

--- a/plugins/wazo_yealink/v87/pkgs/pkgs.db
+++ b/plugins/wazo_yealink/v87/pkgs/pkgs.db
@@ -155,10 +155,10 @@ size: 753583408
 sha1sum: 37e035ee92f9f2ba98af39c1d529ab943fadda10
 
 [file_T7T8-fw]
-filename: T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom
-url: http://provd.wazo.community/firmwares/yealink/T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom
-size: 47483744
-sha1sum: ae351cfb185d002ac0e50177915cf67054270c8d
+filename: T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom
+url: http://provd.wazo.community/firmwares/yealink/T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.34.rom
+size: 43419504
+sha1sum: 207ff6d250b0150af36d7e8e4e6dbdc43ffafa17
 
 [file_T88x-fw]
 filename: T88(T88W,T88V)-192.87.0.10.rom

--- a/plugins/wazo_yealink/v87/pkgs/pkgs.db
+++ b/plugins/wazo_yealink/v87/pkgs/pkgs.db
@@ -15,8 +15,15 @@ install: yealink-fw
 [pkg_T7T8-fw]
 description: Firmware for Yealink T7x & T8x
 description_fr: Micrologiciel pour Yealink T7x & T8x
-version: 185.87.0.10
+version: 185.87.0.33
 files: T7T8-fw
+install: yealink-fw
+
+[pkg_T88x-fw]
+description: Firmware for Yealink T88x
+description_fr: Micrologiciel pour Yealink T88x
+version: 192.87.0.10
+files: T88x-fw
 install: yealink-fw
 
 [pkg_AX8X-fw]
@@ -29,7 +36,7 @@ install: yealink-fw
 [pkg_W70B-fw]
 description: Firmware for Yealink W70B
 description_fr: Micrologiciel pour Yealink W70B
-version: 146.87.0.15
+version: 146.87.0.21
 files: W70B-fw
 install: yealink-fw
 
@@ -43,14 +50,14 @@ install: yealink-fw
 [pkg_W80DM-fw]
 description: Firmware for Yealink W80DM
 description_fr: Micrologiciel pour Yealink W80DM
-version: 103.87.0.10
+version: 103.87.0.18
 files: W80DM-fw
 install: yealink-fw
 
 [pkg_W75DM-fw]
 description: Firmware for Yealink W75DM and W75B
 description_fr: Micrologiciel pour Yealink W75DM et W75B
-version: 175.87.0.10
+version: 175.87.0.18
 files: W75DM-fw
 install: yealink-fw
 
@@ -64,7 +71,7 @@ install: yealink-fw
 [pkg_W90DM-fw]
 description: Firmware for Yealink W90DM
 description_fr: Micrologiciel pour Yealink W90DM
-version: 130.87.0.10
+version: 130.87.0.18
 files: W90DM-fw
 install: yealink-fw
 
@@ -141,10 +148,16 @@ size: 753583408
 sha1sum: 37e035ee92f9f2ba98af39c1d529ab943fadda10
 
 [file_T7T8-fw]
-filename: T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom
-url: http://provd.wazo.community/firmwares/yealink/T77(T73,T74,T73U,T74U,T77,T77U,T85W,T87W)-185.87.0.10.rom
-size: 46668144
-sha1sum: c972484415a0b4b45ee24c846ecc5d36d65a6527
+filename: T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom
+url: http://provd.wazo.community/firmwares/yealink/T77(T73,T74,T73U,T74U,T77U,T85W,T87W)-185.87.0.33.rom
+size: 47483744
+sha1sum: ae351cfb185d002ac0e50177915cf67054270c8d
+
+[file_T88x-fw]
+filename: T88(T88W,T88V)-192.87.0.10.rom
+url: http://provd.wazo.community/firmwares/yealink/T88(T88W,T88V)-192.87.0.10.rom
+size: 893504432
+sha1sum: f0e72143075b6f0c89bbcfc8c604d38f3404bca7
 
 [file_AX8X-fw]
 filename: AX83(AX83,AX86)-180.87.0.15.rom
@@ -153,10 +166,10 @@ size: 77761216
 sha1sum: 6dde809fce7c8781891156c85d83b94a91daaa63
 
 [file_W70B-fw]
-filename: W70B-146.87.0.15.rom
-url: http://provd.wazo.community/firmwares/yealink/W70B-146.87.0.15.rom
-size: 22066224
-sha1sum: 215d69345c9318206bf8dad2e6864be16990c836
+filename: W70B-146.87.0.21.rom
+url: http://provd.wazo.community/firmwares/yealink/W70B-146.87.0.21.rom
+size: 22258512
+sha1sum: 5423916e902da326fe391203e6782df3ac6f46f0
 
 [file_W80B-fw]
 filename: W80B-103.87.0.10.rom
@@ -165,16 +178,16 @@ size: 27997808
 sha1sum: c932819fe6d991804acc63e4ec0da4b094078d0c
 
 [file_W80DM-fw]
-filename: W80DM-103.87.0.10.rom
-url: http://provd.wazo.community/firmwares/yealink/W80DM-103.87.0.10.rom
-size: 45266400
-sha1sum: 4d6dd50cb4b5528e523af571e5db1c721c479b6e
+filename: W80DM-103.87.0.18.rom
+url: http://provd.wazo.community/firmwares/yealink/W80DM-103.87.0.18.rom
+size: 46423216
+sha1sum: f20b2fd778b8bdf9bdbd85033ac084d1c4c1b58e
 
 [file_W75DM-fw]
-filename: W75DM-175.87.0.10.rom
-url: http://provd.wazo.community/firmwares/yealink/W75DM-175.87.0.10.rom
-size: 46633248
-sha1sum: 5161cfdcca6ad79622cad84ed636d9f62841b6ce
+filename: W75DM-175.87.0.18.rom
+url: http://provd.wazo.community/firmwares/yealink/W75DM-175.87.0.18.rom
+size: 47861440
+sha1sum: 27fda4d0fd297824ca2ef4a5b9b4dceaa303e234
 
 [file_W90B-fw]
 filename: W90B-130.87.0.10.rom
@@ -183,10 +196,10 @@ size: 28203264
 sha1sum: 8503de2bae12644a79d4252f9808721fdbf52ef9
 
 [file_W90DM-fw]
-filename: W90DM-130.87.0.10.rom
-url: http://provd.wazo.community/firmwares/yealink/W90DM-130.87.0.10.rom
-size: 45686608
-sha1sum: 095c87b54d1dfc5018b36449bdb909ba268d5e84
+filename: W90DM-130.87.0.18.rom
+url: http://provd.wazo.community/firmwares/yealink/W90DM-130.87.0.18.rom
+size: 46846944
+sha1sum: 10d8630e9f73f039df27c0acf57c37df88e1aac1
 
 [file_W56H-fw]
 filename: W56H-61.87.0.5.rom

--- a/plugins/wazo_yealink/v87/pkgs/pkgs.db
+++ b/plugins/wazo_yealink/v87/pkgs/pkgs.db
@@ -15,7 +15,7 @@ install: yealink-fw
 [pkg_T7T8-fw]
 description: Firmware for Yealink T7x & T8x
 description_fr: Micrologiciel pour Yealink T7x & T8x
-version: 185.87.0.33
+version: 185.87.0.34
 files: T7T8-fw
 install: yealink-fw
 

--- a/plugins/wazo_yealink/v87/pkgs/pkgs.db
+++ b/plugins/wazo_yealink/v87/pkgs/pkgs.db
@@ -22,7 +22,7 @@ install: yealink-fw
 [pkg_AX8X-fw]
 description: Firmware for Yealink AX83H & AX86R
 description_fr: Micrologiciel pour Yealink AX83H & AX86R
-version: 180.87.0.5
+version: 180.87.0.15
 files: AX8X-fw
 install: yealink-fw
 
@@ -147,10 +147,10 @@ size: 46668144
 sha1sum: c972484415a0b4b45ee24c846ecc5d36d65a6527
 
 [file_AX8X-fw]
-filename: AX83(AX83,AX86)-180.87.0.5.rom
-url: http://provd.wazo.community/firmwares/yealink/AX83(AX83,AX86)-180.87.0.5.rom
-size: 38007952
-sha1sum: 9a71f73be9fcf63ace754a94932111c1c3c29684
+filename: AX83(AX83,AX86)-180.87.0.15.rom
+url: http://provd.wazo.community/firmwares/yealink/AX83(AX83,AX86)-180.87.0.15.rom
+size: 77761216
+sha1sum: 6dde809fce7c8781891156c85d83b94a91daaa63
 
 [file_W70B-fw]
 filename: W70B-146.87.0.15.rom

--- a/plugins/wazo_yealink/v87/pkgs/pkgs.db
+++ b/plugins/wazo_yealink/v87/pkgs/pkgs.db
@@ -40,10 +40,24 @@ version: 146.87.0.21
 files: W70B-fw
 install: yealink-fw
 
+[pkg_W75B-fw]
+description: Firmware for Yealink W75B
+description_fr: Micrologiciel pour W75B
+version: 175.87.0.18
+files: W75B-fw
+install: yealink-fw
+
+[pkg_W75DM-fw]
+description: Firmware for Yealink W75DM
+description_fr: Micrologiciel pour Yealink W75DM
+version: 175.87.0.18
+files: W75DM-fw
+install: yealink-fw
+
 [pkg_W80B-fw]
 description: Firmware for Yealink W80B
 description_fr: Micrologiciel pour Yealink W80B
-version: 103.87.0.10
+version: 103.87.0.18
 files: W80B-fw
 install: yealink-fw
 
@@ -54,17 +68,10 @@ version: 103.87.0.18
 files: W80DM-fw
 install: yealink-fw
 
-[pkg_W75DM-fw]
-description: Firmware for Yealink W75DM and W75B
-description_fr: Micrologiciel pour Yealink W75DM et W75B
-version: 175.87.0.18
-files: W75DM-fw
-install: yealink-fw
-
 [pkg_W90B-fw]
 description: Firmware for Yealink W90B
 description_fr: Micrologiciel pour Yealink W90B
-version: 130.87.0.10
+version: 130.87.0.18
 files: W90B-fw
 install: yealink-fw
 
@@ -171,17 +178,11 @@ url: http://provd.wazo.community/firmwares/yealink/W70B-146.87.0.21.rom
 size: 22258512
 sha1sum: 5423916e902da326fe391203e6782df3ac6f46f0
 
-[file_W80B-fw]
-filename: W80B-103.87.0.10.rom
-url: http://provd.wazo.community/firmwares/yealink/W80B-103.87.0.10.rom
-size: 27997808
-sha1sum: c932819fe6d991804acc63e4ec0da4b094078d0c
-
-[file_W80DM-fw]
-filename: W80DM-103.87.0.18.rom
-url: http://provd.wazo.community/firmwares/yealink/W80DM-103.87.0.18.rom
-size: 46423216
-sha1sum: f20b2fd778b8bdf9bdbd85033ac084d1c4c1b58e
+[file_W75B-fw]
+filename: W75B-175.87.0.18.rom
+url: http://provd.wazo.community/firmwares/yealink/W75B-175.87.0.18.rom
+size: 29108528
+sha1sum: ca9a01579576cc049846eb8ed2a13b6c9ef342a5
 
 [file_W75DM-fw]
 filename: W75DM-175.87.0.18.rom
@@ -189,11 +190,23 @@ url: http://provd.wazo.community/firmwares/yealink/W75DM-175.87.0.18.rom
 size: 47861440
 sha1sum: 27fda4d0fd297824ca2ef4a5b9b4dceaa303e234
 
+[file_W80B-fw]
+filename: W80B-103.87.0.18.rom
+url: http://provd.wazo.community/firmwares/yealink/W80B-103.87.0.18.rom
+size: 28329680
+sha1sum: b0bc1bf63eeb2ec473bb18aaa0d2caf5e1a8d50b
+
+[file_W80DM-fw]
+filename: W80DM-103.87.0.18.rom
+url: http://provd.wazo.community/firmwares/yealink/W80DM-103.87.0.18.rom
+size: 46423216
+sha1sum: f20b2fd778b8bdf9bdbd85033ac084d1c4c1b58e
+
 [file_W90B-fw]
-filename: W90B-130.87.0.10.rom
-url: http://provd.wazo.community/firmwares/yealink/W90B-130.87.0.10.rom
-size: 28203264
-sha1sum: 8503de2bae12644a79d4252f9808721fdbf52ef9
+filename: W90B-130.87.0.18.rom
+url: http://provd.wazo.community/firmwares/yealink/W90B-130.87.0.18.rom
+size: 28538688
+sha1sum: 2894f3a5e0ce18f9392044b47e6dda2ff49fccd9
 
 [file_W90DM-fw]
 filename: W90DM-130.87.0.18.rom

--- a/plugins/wazo_yealink/v87/plugin-info
+++ b/plugins/wazo_yealink/v87/plugin-info
@@ -61,7 +61,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T73(U)(W), 185.87.0.10": {
+        "Yealink, T73(U)(W), 185.87.0.33": {
             "lines": 12,
             "high_availability": true,
             "function_keys": 48,
@@ -70,7 +70,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T74(U)(W), 185.87.0.10": {
+        "Yealink, T74(U)(W), 185.87.0.33": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 60,
@@ -79,7 +79,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T77(U), 185.87.0.10": {
+        "Yealink, T77(U), 185.87.0.33": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 95,
@@ -88,7 +88,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T85(W), 185.87.0.10": {
+        "Yealink, T85(W), 185.87.0.33": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 72,
@@ -97,7 +97,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T87(W), 185.87.0.10": {
+        "Yealink, T87(W), 185.87.0.33": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 95,
@@ -106,7 +106,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T88(W)(V), 185.87.0.10": {
+        "Yealink, T88(W)(V), 192.87.0.10": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 95,
@@ -116,9 +116,9 @@
             "protocol": "sip"
         },
 
-        "Yealink, W70B, 146.87.0.15": {
+        "Yealink, W70B, 146.87.0.21": {
             "lines": 10,
-            "high_availability": false,
+            "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,
             "switchboard": false,
@@ -128,7 +128,7 @@
         },
         "Yealink, W75B, 175.87.0.10": {
             "lines": 20,
-            "high_availability": false,
+            "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,
             "switchboard": false,
@@ -136,9 +136,9 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W75DM, 175.87.0.10": {
+        "Yealink, W75DM, 175.87.0.18": {
             "lines": 20,
-            "high_availability": false,
+            "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,
             "switchboard": false,
@@ -148,7 +148,7 @@
         },
         "Yealink, W80B, 103.87.0.10": {
             "lines": 30,
-            "high_availability": false,
+            "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,
             "switchboard": false,
@@ -156,9 +156,9 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W80DM, 103.87.0.10": {
+        "Yealink, W80DM, 103.87.0.18": {
             "lines": 30,
-            "high_availability": false,
+            "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,
             "switchboard": false,
@@ -166,9 +166,19 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W90, 130.87.0.10": {
+        "Yealink, W90B, 130.87.0.10": {
             "lines": 250,
-            "high_availability": false,
+            "high_availability": true,
+            "function_keys": 0,
+            "expansion_modules": 0,
+            "switchboard": false,
+            "type": "dect",
+            "multicell": true,
+            "protocol": "sip"
+        },
+        "Yealink, W90DM, 130.87.0.18": {
+            "lines": 250,
+            "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,
             "switchboard": false,

--- a/plugins/wazo_yealink/v87/plugin-info
+++ b/plugins/wazo_yealink/v87/plugin-info
@@ -126,7 +126,7 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W75B, 175.87.0.10": {
+        "Yealink, W75B, 175.87.0.18": {
             "lines": 20,
             "high_availability": true,
             "function_keys": 0,
@@ -146,7 +146,7 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W80B, 103.87.0.10": {
+        "Yealink, W80B, 103.87.0.18": {
             "lines": 30,
             "high_availability": true,
             "function_keys": 0,
@@ -166,7 +166,7 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W90B, 130.87.0.10": {
+        "Yealink, W90B, 130.87.0.18": {
             "lines": 250,
             "high_availability": true,
             "function_keys": 0,

--- a/plugins/wazo_yealink/v87/plugin-info
+++ b/plugins/wazo_yealink/v87/plugin-info
@@ -61,7 +61,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T73(U)(W), 185.87.0.33": {
+        "Yealink, T73(U)(W), 185.87.0.34": {
             "lines": 12,
             "high_availability": true,
             "function_keys": 48,
@@ -70,7 +70,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T74(U)(W), 185.87.0.33": {
+        "Yealink, T74(U)(W), 185.87.0.34": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 60,
@@ -79,7 +79,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T77(U), 185.87.0.33": {
+        "Yealink, T77(U), 185.87.0.34": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 95,
@@ -88,7 +88,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T85(W), 185.87.0.33": {
+        "Yealink, T85(W), 185.87.0.34": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 72,
@@ -97,7 +97,7 @@
             "type": "deskphone",
             "protocol": "sip"
         },
-        "Yealink, T87(W), 185.87.0.33": {
+        "Yealink, T87(W), 185.87.0.34": {
             "lines": 16,
             "high_availability": true,
             "function_keys": 95,

--- a/plugins/wazo_yealink/v87/plugin-info
+++ b/plugins/wazo_yealink/v87/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Plugin for Yealink for AX83H & AX86R, T5xW, T7X, T8X, W70, W75, W80 and W90 series in version 87.",
     "description_fr": "Greffon pour Yealink pour les series AX83H & AX86R, T5xW, T7X, T8X, W70, W75, W80 and W90 en version 87.",
     "vendor" : "Yealink",
@@ -7,7 +7,7 @@
     "vendor.description" : "Companies choose Yealink for that enable their geographically dispersed workforces to communicate and collaborate more effectively and productively over distances. Through the service provided by Yealink, people connect and collaborate from their desktops, meeting rooms, class rooms, and mobile setting.",
     "vendor.official" : 1,
     "capabilities": {
-        "Yealink, AX86R, 180.87.0.5": {
+        "Yealink, AX86R, 180.87.0.15": {
             "lines": 2,
             "high_availability": true,
             "function_keys": 0,
@@ -16,7 +16,7 @@
             "type": "wifidect",
             "protocol": "sip"
         },
-        "Yealink, AX83H, 180.87.0.5": {
+        "Yealink, AX83H, 180.87.0.15": {
             "lines": 2,
             "high_availability": true,
             "function_keys": 0,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates multiple device firmware versions and package metadata, which can affect provisioning and upgrade behavior for deployed phones if versions/URLs are wrong. Logic changes are minimal, but incorrect hashes or capability/version mismatches could break installs.
> 
> **Overview**
> Updates the Yealink v87 plugin to newer firmware releases across the T7x/T8x, AX8x, and W70/W75/W80/W90 lines, including new URLs/sizes/SHA1s and updated `MODEL_INFO` mappings.
> 
> Adds dedicated T88x firmware packaging (`pkg_T88x-fw`) and adjusts T88W/T88V to use the new 192.87.0.10 firmware instead of the shared T7/T8 bundle.
> 
> Bumps plugin version to `1.2.1` and refreshes `plugin-info` capability entries to match the new firmware versions, including enabling `high_availability` for the W70/W75/W80/W90 DECT devices and splitting W90 capabilities into `W90B` and `W90DM`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77443b3d623d97acc53ac5df9aeb77c4de10be9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->