### PR TITLE
[ITEM-254] yealink: add new MAC OUI for DHCP

### DIFF
--- a/dhcp/dhcp/dhcpd_update/yealink.conf
+++ b/dhcp/dhcp/dhcpd_update/yealink.conf
@@ -38,39 +38,9 @@ subclass "voip-mac-address-prefix" 1:EC:1D:A9 {
     log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:EC:1D:A9"));
 }
 
-subclass "voip-mac-address-prefix" 1:00:15:65 {
-    option tftp-server-name = config-option VOIP.http-server-uri;
-    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:00:15:65"));
-}
-
-subclass "voip-mac-address-prefix" 1:E4:34:D7 {
-    option tftp-server-name = config-option VOIP.http-server-uri;
-    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:E4:34:D7"));
-}
-
-subclass "voip-mac-address-prefix" 1:80:5E:C0 {
-    option tftp-server-name = config-option VOIP.http-server-uri;
-    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:80:5E:C0"));
-}
-
-subclass "voip-mac-address-prefix" 1:80:5E:0C {
-    option tftp-server-name = config-option VOIP.http-server-uri;
-    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:80:5E:0C"));
-}
-
-subclass "voip-mac-address-prefix" 1:24:9A:D8 {
-    option tftp-server-name = config-option VOIP.http-server-uri;
-    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:24:9A:D8"));
-}
-
 subclass "voip-mac-address-prefix" 1:34:97:D7 {
     option tftp-server-name = config-option VOIP.http-server-uri;
     log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:34:97:D7"));
-}
-
-subclass "voip-mac-address-prefix" 1:44:DB:D2 {
-    option tftp-server-name = config-option VOIP.http-server-uri;
-    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:44:DB:D2"));
 }
 
 subclass "voip-mac-address-prefix" 1:B0:61:A9 {

--- a/dhcp/dhcp/dhcpd_update/yealink.conf
+++ b/dhcp/dhcp/dhcpd_update/yealink.conf
@@ -37,3 +37,53 @@ subclass "voip-mac-address-prefix" 1:EC:1D:A9 {
     option tftp-server-name = config-option VOIP.http-server-uri;
     log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:EC:1D:A9"));
 }
+
+subclass "voip-mac-address-prefix" 1:00:15:65 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:00:15:65"));
+}
+
+subclass "voip-mac-address-prefix" 1:E4:34:D7 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:E4:34:D7"));
+}
+
+subclass "voip-mac-address-prefix" 1:80:5E:C0 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:80:5E:C0"));
+}
+
+subclass "voip-mac-address-prefix" 1:80:5E:0C {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:80:5E:0C"));
+}
+
+subclass "voip-mac-address-prefix" 1:24:9A:D8 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:24:9A:D8"));
+}
+
+subclass "voip-mac-address-prefix" 1:34:97:D7 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:34:97:D7"));
+}
+
+subclass "voip-mac-address-prefix" 1:44:DB:D2 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:44:DB:D2"));
+}
+
+subclass "voip-mac-address-prefix" 1:B0:61:A9 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:B0:61:A9"));
+}
+
+subclass "voip-mac-address-prefix" 1:C4:FC:22 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:C4:FC:22"));
+}
+
+subclass "voip-mac-address-prefix" 1:F0:16:53 {
+    option tftp-server-name = config-option VOIP.http-server-uri;
+    log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Yealink PREFIX 1:F0:16:53"));
+}

--- a/plugins/wazo_yealink/v86/common.py
+++ b/plugins/wazo_yealink/v86/common.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -41,7 +41,13 @@ KNOWN_MAC_PREFIXES = (
     b'805ec0',
     b'805e0c',  # NOTE(afournier): not a mistake
     b'249ad8',
+    b'3497d7',
     b'44dbd2',
+    b'644f56',
+    b'b061a9',
+    b'c4fc22',
+    b'ec1da9',
+    b'f01653',
 )
 
 

--- a/plugins/wazo_yealink/v86/plugin-info
+++ b/plugins/wazo_yealink/v86/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.10",
+    "version": "1.4.11",
     "description": "Plugin for Yealink for CP920, CP925, CP965, T27G, T3X, T4X and T5X series in version 86.",
     "description_fr": "Greffon pour Yealink pour les series CP920, CP925, CP965, T27G, T3X, T4X et T5X en version 86.",
     "vendor" : "Yealink",

--- a/plugins/wazo_yealink/v87/common.py
+++ b/plugins/wazo_yealink/v87/common.py
@@ -41,7 +41,13 @@ KNOWN_MAC_PREFIXES = (
     b'805ec0',
     b'805e0c',  # NOTE(afournier): not a mistake
     b'249ad8',
+    b'3497d7',
     b'44dbd2',
+    b'644f56',
+    b'b061a9',
+    b'c4fc22',
+    b'ec1da9',
+    b'f01653',
 )
 
 

--- a/plugins/wazo_yealink/v87/plugin-info
+++ b/plugins/wazo_yealink/v87/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Plugin for Yealink for AX83H & AX86R, T5xW, T7X, T8X, W70, W75, W80 and W90 series in version 87.",
     "description_fr": "Greffon pour Yealink pour les series AX83H & AX86R, T5xW, T7X, T8X, W70, W75, W80 and W90 en version 87.",
     "vendor" : "Yealink",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding additional Yealink MAC/OUI prefixes and bumping plugin versions, with no behavioral changes beyond matching more devices.
> 
> **Overview**
> Adds several new Yealink MAC/OUI prefixes to `dhcpd_update/yealink.conf` so DHCP clients with those prefixes are routed to the VoIP HTTP/TFTP provisioning server and logged accordingly.
> 
> Updates the Yealink provisioning plugins (`v86` and `v87`) to recognize the same new prefixes via `KNOWN_MAC_PREFIXES`, and bumps plugin versions (`v86` to `1.4.11`, `v87` to `1.2.2`) along with a copyright year update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc658ad809dc85fb6c69ab1d77f93db90e5ec862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->