### PR TITLE
🐛 YEALINK | v87 | Fix support numbers lines & upgrade firmware

### DIFF
--- a/plugins/wazo_yealink/v87/common.py
+++ b/plugins/wazo_yealink/v87/common.py
@@ -445,12 +445,12 @@ class BaseYealinkPlugin(StandardPlugin):
         'T88W': 16,
         'T88V': 16,
         'W70B': 10,
-        'W75B': 0,
+        'W75B': 20,
         'W75DM': 20,
-        'W80DM': 30,
-        'W80B': 0,
+        'W80DM': 100,
+        'W80B': 100,
         'W90DM': 250,
-        'W90B': 0,
+        'W90B': 250,
     }
     _SENSITIVE_FILENAME_REGEX = re.compile(r'^[0-9a-f]{12}\.cfg')
 

--- a/plugins/wazo_yealink/v87/entry.py
+++ b/plugins/wazo_yealink/v87/entry.py
@@ -108,13 +108,13 @@ MODEL_INFO = {
         'handsets_fw': HANDSETS_FW,
     },
     'W80DM': {
-        'version': '103.87.0.18',
-        'firmware': '$PN-103.87.0.18.rom',
+        'version': '103.87.0.30',
+        'firmware': '$PN-103.87.0.30.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W80B': {
-        'version': '103.87.0.18',
-        'firmware': '$PN-103.87.0.18.rom',
+        'version': '103.87.0.30',
+        'firmware': '$PN-103.87.0.30.rom',
         'handsets_fw': HANDSETS_FW,
     },
     'W90DM': {

--- a/plugins/wazo_yealink/v87/pkgs/pkgs.db
+++ b/plugins/wazo_yealink/v87/pkgs/pkgs.db
@@ -57,14 +57,14 @@ install: yealink-fw
 [pkg_W80B-fw]
 description: Firmware for Yealink W80B
 description_fr: Micrologiciel pour Yealink W80B
-version: 103.87.0.18
+version: 103.87.0.30
 files: W80B-fw
 install: yealink-fw
 
 [pkg_W80DM-fw]
 description: Firmware for Yealink W80DM
 description_fr: Micrologiciel pour Yealink W80DM
-version: 103.87.0.18
+version: 103.87.0.30
 files: W80DM-fw
 install: yealink-fw
 
@@ -191,16 +191,16 @@ size: 47861440
 sha1sum: 27fda4d0fd297824ca2ef4a5b9b4dceaa303e234
 
 [file_W80B-fw]
-filename: W80B-103.87.0.18.rom
-url: http://provd.wazo.community/firmwares/yealink/W80B-103.87.0.18.rom
-size: 28329680
-sha1sum: b0bc1bf63eeb2ec473bb18aaa0d2caf5e1a8d50b
+filename: W80B-103.87.0.30.rom
+url: http://provd.wazo.community/firmwares/yealink/W80B-103.87.0.30.rom
+size: 28270480
+sha1sum: 5db7ac25a3bef8a3a4299bafdc8aefb52d56bf40
 
 [file_W80DM-fw]
-filename: W80DM-103.87.0.18.rom
-url: http://provd.wazo.community/firmwares/yealink/W80DM-103.87.0.18.rom
-size: 46423216
-sha1sum: f20b2fd778b8bdf9bdbd85033ac084d1c4c1b58e
+filename: W80DM-103.87.0.30.rom
+url: http://provd.wazo.community/firmwares/yealink/W80DM-103.87.0.30.rom
+size: 45541504
+sha1sum: bb1d354fad9bbefc2a4bbac2707bcd47a6351853
 
 [file_W90B-fw]
 filename: W90B-130.87.0.18.rom

--- a/plugins/wazo_yealink/v87/plugin-info
+++ b/plugins/wazo_yealink/v87/plugin-info
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Plugin for Yealink for AX83H & AX86R, T5xW, T7X, T8X, W70, W75, W80 and W90 series in version 87.",
     "description_fr": "Greffon pour Yealink pour les series AX83H & AX86R, T5xW, T7X, T8X, W70, W75, W80 and W90 en version 87.",
     "vendor" : "Yealink",
@@ -146,8 +146,8 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W80B, 103.87.0.18": {
-            "lines": 30,
+        "Yealink, W80B, 103.87.0.30": {
+            "lines": 100,
             "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,
@@ -156,8 +156,8 @@
             "multicell": false,
             "protocol": "sip"
         },
-        "Yealink, W80DM, 103.87.0.18": {
-            "lines": 30,
+        "Yealink, W80DM, 103.87.0.30": {
+            "lines": 100,
             "high_availability": true,
             "function_keys": 0,
             "expansion_modules": 0,


### PR DESCRIPTION
Updates the Yealink v87 plugin metadata and configuration defaults to reflect newer W80B/W80DM firmware and corrected maximum supported SIP line counts for several DECT base/manager models.

Changes:

Bump v87 plugin version to 1.2.3.
Upgrade W80B/W80DM firmware references from 103.87.0.18 to 103.87.0.30 (metadata, package DB, and model info).
Increase declared/configured SIP line capacity for W75B, W80B/W80DM, and W90B to match expected device capabilities.
